### PR TITLE
revert default rendering hosts file

### DIFF
--- a/authoring/items/nextjs-starter/DefaultRenderingHost/Default.yml
+++ b/authoring/items/nextjs-starter/DefaultRenderingHost/Default.yml
@@ -1,25 +1,36 @@
-﻿---
-ID: "78878cbd-e8d3-29a0-6d85-65f7ba3ec0fb"
+﻿ID: "dffee92b-0441-45a4-9207-67810b72bd46"
 Parent: "895e25c4-12b2-4b2c-8233-82f3b79eef53"
 Template: "bc71d442-3e4f-46ba-887c-746e54f9bb83"
 Path: /sitecore/system/Settings/Services/Rendering Hosts/Default
 SharedFields:
-- ID: "3121c257-53cf-464a-b736-98b418876057"
-  Hint: AppName
-  Value: nextjsstarter
-- ID: "94470b31-e282-4d8d-bc54-85689efb294c"
-  Hint: ServerSideRenderingEngineConfigUrl
-  Value: "https://xmc-3thkowrbblthbrhg2xcm4j-eh.sitecorecloud.io/api/editing/config"
-- ID: "9c6106ea-7a5a-48e2-8cad-f0f693b1e2d4"
-  Hint: __Read Only
-  Value: 1
 - ID: "e32c1801-79b3-4fc1-a9c4-3c6e6c2968ae"
   Hint: ServerSideRenderingEngineApplicationUrl
-  Value: "https://xmc-3thkowrbblthbrhg2xcm4j-eh.sitecorecloud.io"
+  Value: "http://rendering-nextjs:3000"
 - ID: "fc76919b-0d7c-4732-865d-2af795fb38a4"
   Hint: ServerSideRenderingEngineEndpointUrl
-  Value: "https://xmc-3thkowrbblthbrhg2xcm4j-eh.sitecorecloud.io/api/editing/render"
+  Value: "http://rendering-nextjs:3000/api/editing/render"
+- ID: "94470b31-e282-4d8d-bc54-85689efb294c"
+  Hint: ServerSideRenderingEngineConfigUrl
+  Value: "http://rendering-nextjs:3000/api/editing/config"
 Languages:
 - Language: en
   Versions:
   - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20220614T103029Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Admin
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "c9cd6f4c-0f8a-45af-8792-044e422401b0"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\xmc-e2e-admin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20220628T155530Z


### PR DESCRIPTION
This PR restores the original `Default.yml` rendering-host configuration to eliminate the CORS error.