### PR TITLE
[product-listing/bold site] Make header stay in place when in editing

### DIFF
--- a/examples/kit-nextjs-product-listing/src/Layout.tsx
+++ b/examples/kit-nextjs-product-listing/src/Layout.tsx
@@ -129,7 +129,9 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
               <DesignLibrary {...layoutData} />
             ) : (
               <>
-                <header className={isPageEditing ? 'editing' : ''}>
+                <header
+                  className={`sticky ${isPageEditing ? 'lg:relative' : 'lg:fixed'} top-0 left-0 right-0 -mb-[38px] lg:mb-0 z-50`}
+                >
                   <div id="header">
                     {route && <Placeholder name="headless-header" rendering={route} />}
                   </div>

--- a/examples/kit-nextjs-product-listing/src/pages/globals.css
+++ b/examples/kit-nextjs-product-listing/src/pages/globals.css
@@ -210,14 +210,6 @@
 
 /* HEADER STYLES */
 
-header {
-  @apply sticky lg:fixed top-0 left-0 right-0 -mb-[38px] lg:mb-0 z-50;
-}
-
-header.editing {
-  @apply lg:relative
-}
-
 .partial-editing-mode header {
   @apply static mb-0 overflow-hidden;
 }


### PR DESCRIPTION
Fixes the issue where components could not be added at the top of the page because of header overlapping placeholder bounds.
Header will stay at the top when in editing mode, and function normally in preview and normal render.