### PR TITLE
Use skate-park as Default rendering host

### DIFF
--- a/xmcloud.build.json
+++ b/xmcloud.build.json
@@ -1,7 +1,7 @@
 {
   "renderingHosts": {
     "nextjsstarter": {
-      "path": "./examples/basic-nextjs",
+      "path": "./examples/kit-nextjs-skate-park",
       "nodeVersion": "22.11.0",
       "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
       "enabled": true,
@@ -38,15 +38,6 @@
     },
     "kit-nextjs-product-starter": {
       "path": "./examples/kit-nextjs-product-listing",
-      "nodeVersion": "22.11.0",
-      "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
-      "enabled": true,
-      "type": "sxa",
-      "buildCommand": "build",
-      "runCommand": "next:start"
-    },
-    "kit-nextjs-skate-park": {
-      "path": "./examples/kit-nextjs-skate-park",
       "nodeVersion": "22.11.0",
       "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
       "enabled": true,


### PR DESCRIPTION
Use kit-nextjs-skate-park as Default rendering host, until Skate Park templates and items are moved from base image to serialized items in repo.