### PR TITLE
[futuristic-drive] Prevent Radix hover indicator from blocking clicks on nav link

### DIFF
--- a/examples/kit-nextjs-location-finder/src/components/ui/navigation-menu.tsx
+++ b/examples/kit-nextjs-location-finder/src/components/ui/navigation-menu.tsx
@@ -24,11 +24,18 @@ const NavigationMenuList = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.List
-    ref={ref}
-    className={cn('group flex flex-1 list-none items-center justify-center space-x-1', className)}
-    {...props}
-  />
+  <>
+    <div className="pointer-events-none absolute inset-0 -z-10">
+      <NavigationMenuPrimitive.List
+        ref={ref}
+        className={cn(
+          'group flex flex-1 list-none items-center justify-center space-x-1 pointer-events-auto',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  </>
 ));
 NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
@@ -102,7 +109,7 @@ const NavigationMenuIndicator = React.forwardRef<
     )}
     {...props}
   >
-    <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+    <div className="pointer-events-none bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
   </NavigationMenuPrimitive.Indicator>
 ));
 NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;


### PR DESCRIPTION
This fixes an issue where the first navigation link (Aero) was unclickable due to an invisible hover indicator i.e `<span>` rendered by `@radix-ui/react-navigation-menu`. Although the indicator had `opacity: 0,` it was absolutely positioned and lacked `pointer-events: none`, causing it to intercept mouse events over the first item.

Fix:
Wrapped the `NavigationMenuPrimitive.List` in a container with `pointer-events-none` and `-z-10`, and applied `pointer-events-auto` to the list itself. This ensures:
- The Radix indicator remains visually rendered but non-interactive
- Navigation items remain fully clickable