### PR TITLE
[Article Starter] Error is thrown when rendering Image in Design Library

### DIFF
--- a/examples/kit-nextjs-article-starter/src/components/sxa/Image.tsx
+++ b/examples/kit-nextjs-article-starter/src/components/sxa/Image.tsx
@@ -46,7 +46,6 @@ export const Banner = (props: ImageProps): JSX.Element => {
 };
 
 export const Default = (props: ImageProps): JSX.Element => {
-  const { page } = useSitecore();
   const { fields, params } = props;
   const sxaStyles = params?.Styles ?? '';
   const classNameList = `component image ${sxaStyles}`.trimEnd();
@@ -65,7 +64,7 @@ export const Default = (props: ImageProps): JSX.Element => {
     return (
       <div className={classNameList}>
         <div className="component-content">
-          {page.mode.isEditing ? <JssImage field={modifyImageProps} /> : ''}
+          <JssImage field={modifyImageProps} />
         </div>
       </div>
     );


### PR DESCRIPTION
Can’t destructure property “Image” is thrown when rendering Image using Soltera (kit-nextjs-article starter) site
We had to check fields before accessing them
Also Image wasn't rendered in DesignLibrary even after the fix of the error due to "isEditing" check (not sure why we rendered empty component in normal mode)