### PR TITLE
Fix for undefined length for product header error

### DIFF
--- a/examples/kit-nextjs-product-listing/src/components/site-three/ProductPageHeader.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/site-three/ProductPageHeader.tsx
@@ -48,7 +48,8 @@ export const Default = (props: ProductPageHeaderProps) => {
   }, [props.fields?.Colors, selectedColor]);
 
   // Fall back to an empty array until the field populates
-  const productImages = props.fields?.Images ?? [];
+  const images = props.fields?.Images ?? [];
+  const productImages = images.length === 2 ? [...images, ...images] : images;
 
   return (
     <section


### PR DESCRIPTION
This PR adds a guard `props.fields.Images` with a safe fallback to prevent the undefined‑length TypeError, while keeping the two‑image duplication logic for smooth carousel looping. 

It solves the related bug as mentioned here: https://sitecore.atlassian.net/browse/XFT-91