### PR TITLE
SITES-2954 Default workflow in three new templates

### DIFF
--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Accordions/AccordionBlock/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Accordions/AccordionBlock/__Standard Values.yml
@@ -7,35 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{75BC6AB0-2492-4129-9F90-CA0BAB019E07}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "92e31907-223b-418f-b4f1-caf730f7b4ff"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "23c31b2b-4652-4755-94b0-184bca384219"
-      Hint: heading
-      Value: $name
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250214T201428Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "2906270e-10a0-4c44-bdc5-684118d755ae"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250214T201450Z
   - Version: 2
     Fields:
     - ID: "23c31b2b-4652-4755-94b0-184bca384219"
@@ -54,11 +34,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "2906270e-10a0-4c44-bdc5-684118d755ae"
+      Value: "e4edf5f3-f7f5-4198-b13f-91e846cd0eeb"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250214T201450Z
+      Value: 20250717T133118Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Accordions/AccordionSlide/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Accordions/AccordionSlide/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "438e58ed-332c-47fb-a6fb-dd855ccae394"
 Parent: "75bc6ab0-2492-4129-9f90-ca0bab019e07"
 Template: "75bc6ab0-2492-4129-9f90-ca0bab019e07"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Accordions/AccordionSlide/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "cbc5f8b6-eb2a-4056-a3a0-728384587f81"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250207T160443Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "59f8ca51-d752-468c-bfe5-b36bc0cc4c9d"
-      Hint: heading
-      Value: $name
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "1f8d0c2f-e8cb-4163-be35-6f1f7e1e7d17"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250207T160619Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -50,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "1f8d0c2f-e8cb-4163-be35-6f1f7e1e7d17"
+      Value: "9745ca55-2b54-4695-bebc-faf037b613ce"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250207T160619Z
+      Value: 20250717T133125Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Hero.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Hero.yml
@@ -12,6 +12,12 @@ SharedFields:
   Value: |
     {1930BBEB-7805-471A-A3BE-4858AC7CF696}
     {44A022DB-56D3-419A-B43B-E27E4D8E9C41}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "65e1d0b8-1d61-4e17-addc-d3f06929fc7b"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{02B9A5BA-4DCD-400A-AE84-0496E15C6B19}"
 Languages:
 - Language: en
   Versions:
@@ -30,11 +36,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "81e2a728-be8b-4770-b3c1-a7ec95b5443a"
+      Value: "bd343bf5-a874-4289-b8e5-240fbbd3012b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240327T124118Z
+      Value: 20250717T133139Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Hero/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Hero/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "02b9a5ba-4dcd-400a-ae84-0496e15c6b19"
+Parent: "ae018465-4e68-4a49-8b15-9702274fa75a"
+Template: "ae018465-4e68-4a49-8b15-9702274fa75a"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Banners/Hero/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "5d06fb9a-e575-42c8-a3cd-566b011d922c"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133139Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "5b008c80-a6e5-40c3-9da7-c2fb341fea66"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133224Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Page Header/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/Page Header/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{B895F657-9A7B-438B-A2F2-95FB1722BE7F}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "8627a074-2769-4f8f-b4ea-9c1229b7bab9"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250304T170529Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "d004242d-bae5-4d25-b572-cf63ba6608df"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250304T215416Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d004242d-bae5-4d25-b572-cf63ba6608df"
+      Value: "4feebc9f-0dee-44ce-be1b-e88b70d5f191"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250304T215416Z
+      Value: 20250717T133235Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/TextBanner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Banners/TextBanner/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "1f9e650e-79a3-44dd-816c-c2ab3eed75b5"
 Parent: "1313c346-ca98-4657-bb96-d89e35b2235f"
 Template: "1313c346-ca98-4657-bb96-d89e35b2235f"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Banners/TextBanner/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "e4b40b4d-928a-4724-8e19-d535f01ee4f1"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240516T150443Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "50d1e3dc-3dec-47bc-96e0-125c7d9d2c87"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240516T150443Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "50d1e3dc-3dec-47bc-96e0-125c7d9d2c87"
+      Value: "1fbafce6-a5cc-4770-8e40-40536cc6539a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240516T150443Z
+      Value: 20250717T133247Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/CTA Sectoins/CallToAction.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/CTA Sectoins/CallToAction.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 50
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "1fae72f5-d85a-4bd8-9d45-c133492d150a"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{FCAA6879-C4B3-47C0-A2E4-C271B592EBE2}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "b0c52c4e-f91c-4ec1-a78d-eb641eb05514"
+      Value: "c7cae301-cdf2-4c1d-88fd-a7bd5e4e789c"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\richard.seal@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250216T143635Z
+      Value: 20250717T132707Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/CTA Sectoins/CallToAction/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/CTA Sectoins/CallToAction/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "fcaa6879-c4b3-47c0-a2e4-c271b592ebe2"
+Parent: "4de6da0c-90e0-407d-8076-c2265e18a1b5"
+Template: "4de6da0c-90e0-407d-8076-c2265e18a1b5"
+Path: "/sitecore/templates/Project/click-click-launch/Components/CTA Sectoins/CallToAction/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "48ddb492-ceaa-4f53-b2bb-4cf5fb4b8fc8"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T132707Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "263607f5-39d5-409b-a81b-c3a268b9c36c"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T132725Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Forms/Submission Form/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Forms/Submission Form/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "12c0ca83-4337-48fc-b68f-6bdbf827a0bd"
 Parent: "27c429a1-13c5-4cda-850d-a4ac041a86a7"
 Template: "27c429a1-13c5-4cda-850d-a4ac041a86a7"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Forms/Submission Form/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "940fd8a7-f668-4a33-bc56-65d661618c80"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250319T172946Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "7e42fb3f-374f-4b00-9ad8-7322172c51d4"
-      Hint: title
-      Value: $name
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "fffb65e8-e963-4671-a42f-6ca83fb135bc"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250319T223841Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -50,11 +31,11 @@ Languages:
       Value: $name
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fffb65e8-e963-4671-a42f-6ca83fb135bc"
+      Value: "5b3f57ac-933b-44eb-8fbf-2d07cc1103e1"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250319T223841Z
+      Value: 20250717T133255Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/FooterNavigationLinksColumn/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/FooterNavigationLinksColumn/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{CFD30FC4-07FA-471E-9F85-3A1BF425C718}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "abdf0b24-195b-4506-8eea-b14f0498391b"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240408T143242Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "96f3ad4e-0191-4b71-b260-e1babdcf5308"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240409T133525Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "96f3ad4e-0191-4b71-b260-e1babdcf5308"
+      Value: "cd14449a-f142-4c11-b927-75a10b928a43"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240409T133525Z
+      Value: 20250717T133308Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GeneralLinkItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GeneralLinkItem/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{CFD30FC4-07FA-471E-9F85-3A1BF425C718}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "f3bdc555-17f2-42c5-99c6-14a0a980aa97"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240820T195958Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "d6aceda7-d2e2-4c2c-bb44-0d6e35967ef7"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240820T200009Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d6aceda7-d2e2-4c2c-bb44-0d6e35967ef7"
+      Value: "d215e2c3-d91e-4c5f-ba39-361c955986ba"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240820T200009Z
+      Value: 20250717T133316Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GlobalFooter/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GlobalFooter/__Standard Values.yml
@@ -9,33 +9,15 @@ SharedFields:
   Value: |
     {CFD30FC4-07FA-471E-9F85-3A1BF425C718}
     {F24978E9-CAB5-4A7F-A836-D423FF20B830}
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "9776fa01-9e46-44c7-baf4-3c5345ddc307"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250314T170845Z
-    - ID: "42460973-3c52-4b54-8ee5-6b335f256705"
-      Hint: tagline
-      Value: Drive Beyond
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "fab063d1-adae-41d4-9f71-8fc7271ea9ae"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d03f6255-b87d-4205-b10d-f3c1ee56aa14"
-      Hint: footerCopyright
-      Value: © Alaris. All rights reserved.
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250314T171124Z
-    - ID: "f76bf9b9-3dfe-4cea-ac52-a87f3043911b"
-      Hint: emailSubscriptionTitle
-      Value: Join the Alaris revolution.
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -46,17 +28,17 @@ Languages:
       Value: Drive Beyond
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fab063d1-adae-41d4-9f71-8fc7271ea9ae"
+      Value: "b197988c-7ab8-4f3f-8e2f-af6f486a2d29"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d03f6255-b87d-4205-b10d-f3c1ee56aa14"
       Hint: footerCopyright
       Value: © Alaris. All rights reserved.
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250314T171124Z
+      Value: 20250717T133326Z
     - ID: "f76bf9b9-3dfe-4cea-ac52-a87f3043911b"
       Hint: emailSubscriptionTitle
       Value: Join the Alaris revolution.

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GlobalHeader/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/GlobalHeader/__Standard Values.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{CFD30FC4-07FA-471E-9F85-3A1BF425C718}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "3fdb0119-861e-48ec-b83e-947ec553cac1"
 Languages:
 - Language: en
   Versions:
@@ -25,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "a9b50eb2-6e50-4aa6-b877-3384fdff6225"
+      Value: "b3e3aed2-abfb-4456-bca0-ca91424bde2c"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250402T123512Z
+      Value: 20250717T133336Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/PrimaryNavigationLinks/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/PrimaryNavigationLinks/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{CFD30FC4-07FA-471E-9F85-3A1BF425C718}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "6b7b2f39-d42d-45bd-b931-af6902d34633"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240404T132800Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "00c9aa4d-958b-41b6-90e9-0beff8711cf8"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240404T132849Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "00c9aa4d-958b-41b6-90e9-0beff8711cf8"
+      Value: "51f202f7-cc28-49ce-ba28-79f2bcbe74e0"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240404T132849Z
+      Value: 20250717T133405Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/SocialLink.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/SocialLink.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "45009f5c-3ee0-48cb-915c-e6b056cb0b7a"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{837DF228-78B8-44EB-8DEB-9B212C99A24A}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "0876a69a-a2ce-4576-b07c-1fa14552829c"
+      Value: "a3c8190b-6c4c-42b3-8ed8-ed889936b19b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240408T080308Z
+      Value: 20250717T133413Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/SocialLink/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Global Elements/SocialLink/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "837df228-78b8-44eb-8deb-9b212c99a24a"
+Parent: "f24978e9-cab5-4a7f-a836-d423ff20b830"
+Template: "f24978e9-cab5-4a7f-a836-d423ff20b830"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Global Elements/SocialLink/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "dba53ce4-b9aa-41b8-a2f6-9141b1727de4"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133413Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "def5deb7-974c-4471-a6a9-1865a98eaa4c"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133420Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero ST/HeroST.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero ST/HeroST.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "e6b5b5be-6ff0-484c-b7df-5ef5b82fdd88"
+  Value: "fee52036-48ce-4d27-ae9c-5a4a70b15e5a"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{19A2D43C-0423-41C2-A532-0E94AD954776}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -61,14 +64,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "9303b2c2-e0da-444f-a56a-2080e43cde65"
+      Value: "bbe46630-d1ad-4765-8028-ae36f344f0a5"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250527T071328Z
+      Value: 20250717T133449Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero ST/HeroST/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero ST/HeroST/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "19a2d43c-0423-41c2-a532-0e94ad954776"
+Parent: "c241957a-b7cc-4bdd-962f-bf8652ed595c"
+Template: "c241957a-b7cc-4bdd-962f-bf8652ed595c"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Hero ST/HeroST/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "6ebf0e96-6c84-4f55-8d30-1ef5d0be6c48"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133449Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "9d094bb8-49eb-45e7-88a6-b83725dcd5eb"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133455Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero Sections/Hero Section.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero Sections/Hero Section.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "d71cd0a5-858f-465f-85b3-4153989a7514"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{F4D18E9E-76F4-4D48-9C60-B24508742B18}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "6ca8d156-4e21-4e9e-8438-ce7968370e05"
+      Value: "a010c2fe-0de8-472f-a024-c692a3027565"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\richard.seal@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250215T111033Z
+      Value: 20250717T133433Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero Sections/Hero Section/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Hero Sections/Hero Section/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "f4d18e9e-76f4-4d48-9c60-b24508742b18"
+Parent: "00f06c82-8bc5-498e-bd1d-e5a6ad827b61"
+Template: "00f06c82-8bc5-498e-bd1d-e5a6ad827b61"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Hero Sections/Hero Section/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "56a147b1-e47e-4653-990a-3a4d0059abe0"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133433Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "6b7d7bdd-de9b-407b-9795-131fcc605794"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133438Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Listing/Article Listing.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Listing/Article Listing.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "6306b5d8-fb5e-4567-8875-6407341c94f6"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{563549CD-43A0-4375-977A-ADE1C361D645}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "12fa1a57-7408-4f30-9eed-a57d83e7e606"
+      Value: "204c6ce4-9c3a-4b5d-bbff-a239e81e225a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250404T163923Z
+      Value: 20250717T133553Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Listing/Article Listing/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Listing/Article Listing/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "563549cd-43a0-4375-977a-ade1c361d645"
+Parent: "705c014a-ced4-409a-89b7-09350cc98116"
+Template: "705c014a-ced4-409a-89b7-09350cc98116"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Listing/Article Listing/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "cc0c82e8-036f-4d6e-9b02-2ef13fe226cc"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133552Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "430b9e8a-772e-4d65-8b2f-fe0d1c36406a"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133559Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Location Search/Location Search Item/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Location Search/Location Search Item/__Standard Values.yml
@@ -7,35 +7,15 @@ SharedFields:
 - ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
   Hint: __Icon
   Value: /~/icon/apps/32x32/Location.png
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "64567b7b-1223-4f70-8fd2-364a3ee7b50f"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250320T164246Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "b56284ce-22e8-4015-9f23-e87a02e8f500"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250320T164704Z
-    - ID: "edac5344-3409-4938-8e8b-a1cf07c3c1a3"
-      Hint: dealershipName
-      Value: $name
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -51,14 +31,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "b56284ce-22e8-4015-9f23-e87a02e8f500"
+      Value: "515ade55-5ed0-4a39-98f5-7708a4bd219a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250320T164704Z
+      Value: 20250717T133635Z
     - ID: "edac5344-3409-4938-8e8b-a1cf07c3c1a3"
       Hint: dealershipName
       Value: $name

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Location Search/Location Search/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Location Search/Location Search/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "7914a4ba-1826-45cf-8429-df63b9b129c6"
 Parent: "f03fd970-82a7-44e0-8b87-6ee7b2d39939"
 Template: "f03fd970-82a7-44e0-8b87-6ee7b2d39939"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Location Search/Location Search/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "21705003-f62c-49d5-b097-cc112f3381d4"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250320T164246Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "ecaae0d0-cec1-438e-a3e1-9f0c0f2d77e2"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d2daabe5-aa5f-42ba-a261-35900e95facc"
-      Hint: title
-      Value: $name
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250320T164252Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -47,14 +28,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ecaae0d0-cec1-438e-a3e1-9f0c0f2d77e2"
+      Value: "aafc4a21-986f-4ad2-943b-a68a755d56fe"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d2daabe5-aa5f-42ba-a261-35900e95facc"
       Hint: title
       Value: $name
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250320T164252Z
+      Value: 20250717T133626Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel Item.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel Item.yml
@@ -10,6 +10,12 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "f124417d-9eee-4767-ac23-a0c6876a0b0b"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{17CD171F-BF03-4DCF-9401-E264CAFF5698}"
 Languages:
 - Language: en
   Versions:
@@ -28,11 +34,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "e8242dcc-b2fa-4176-a999-ba9ca5438f12"
+      Value: "03c1d71d-e2b1-4be5-a814-8c3ea21746bc"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250318T185241Z
+      Value: 20250717T133716Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel Item/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel Item/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "17cd171f-bf03-4dcf-9401-e264caff5698"
+Parent: "03ba85aa-ad3e-412b-b6c3-0c2af639b49f"
+Template: "03ba85aa-ad3e-412b-b6c3-0c2af639b49f"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Media/Image Carousel Item/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "9cce194e-0f79-470d-a5bb-7612d8c3c9a9"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133716Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "f9e52256-cb1e-44f2-b8b2-7b54c559c23b"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133729Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Carousel/__Standard Values.yml
@@ -7,35 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{03BA85AA-AD3E-412B-B6C3-0C2AF639B49F}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "df5ce816-e4d3-4a37-ba09-3a94ad115e3b"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250318T185559Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "a2a6bbc1-e2c6-46e4-9188-7b35b6e482a8"
-    - ID: "9752a97a-2e6a-4040-8e56-49c9a1498ce7"
-      Hint: title
-      Value: $name
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250318T185628Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -51,14 +31,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "a2a6bbc1-e2c6-46e4-9188-7b35b6e482a8"
+      Value: "585b9720-1def-4ca1-ba38-e27e0247f3c1"
     - ID: "9752a97a-2e6a-4040-8e56-49c9a1498ce7"
       Hint: title
       Value: $name
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250318T185628Z
+      Value: 20250717T133706Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Gallery.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Gallery.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "a2e54e2e-48ec-494a-947d-cfd31a61921c"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{348F76FC-9217-453E-9BB1-96FECE512573}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "bc996f23-fb37-4b33-a526-2e2ca12d4cc0"
+      Value: "1a6a085f-18d5-4d2e-bc95-07c8a3e013cd"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250321T114042Z
+      Value: 20250717T133739Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Gallery/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image Gallery/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "348f76fc-9217-453e-9bb1-96fece512573"
+Parent: "4eb24890-61ec-4283-8c61-c55a86d1fe2a"
+Template: "4eb24890-61ec-4283-8c61-c55a86d1fe2a"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Media/Image Gallery/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "2917b700-409a-41a1-a3e4-d6f5ceca11d8"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133739Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "998a06f9-088a-477d-8bbe-85311175bfbc"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133746Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "42d19f2f-b05a-4a3f-bd18-562ad08a4357"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{131C7F82-7161-4D87-B2E4-130FE0029AB4}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "af4c3209-afc4-4ab9-83dc-d3e4e09f4aff"
+      Value: "68770377-6cba-4e88-8c5b-89b949d1763f"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240305T165140Z
+      Value: 20250717T133649Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Image/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "131c7f82-7161-4d87-b2e4-130fe0029ab4"
+Parent: "3720c1c9-5ef8-4ba1-828b-a4672503a1ae"
+Template: "3720c1c9-5ef8-4ba1-828b-a4672503a1ae"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Media/Image/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ba28b02b-a841-461c-87c4-3919317ddf6e"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133649Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "eaa7d2cd-880c-4256-b8e3-f37c87b94c96"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133657Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Logo List Image.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Logo List Image.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "bfa31aa3-9a4f-4ecf-9ee2-5574ca05a751"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{8D702474-D792-417A-A224-A3E9983AEE92}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "bdc6ffbb-c6ea-4063-90d8-c441f26be130"
+      Value: "bc36ad43-6b61-49c6-9ee0-addc6f3261a4"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250304T172253Z
+      Value: 20250717T133800Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Logo List Image/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Logo List Image/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "8d702474-d792-417a-a224-a3e9983aee92"
+Parent: "b895f657-9a7b-438b-a2f2-95fb1722be7f"
+Template: "b895f657-9a7b-438b-a2f2-95fb1722be7f"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Media/Logo List Image/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "4c444db2-0253-40ed-8108-46d2aa24ce51"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133800Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "9c5468c2-19c2-47fb-9900-0487b490ed69"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133805Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Video/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Media/Video/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "3daf4365-995a-4623-951f-d3b35e22f513"
 Parent: "13033574-ef4a-44a2-875f-cf4e7ca3592f"
 Template: "13033574-ef4a-44a2-875f-cf4e7ca3592f"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Media/Video/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "a82d10d2-c0d5-4340-bc1e-d39723d7afd6"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250221T203459Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "4251d47d-dd93-4f6d-ba3f-ea0331bcd23a"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250221T203459Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "4251d47d-dd93-4f6d-ba3f-ea0331bcd23a"
+      Value: "3aa8b682-5ef1-49b5-ba11-1f612dd2d4ec"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250221T203459Z
+      Value: 20250717T133813Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Indexing Base.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Indexing Base.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "93ce5eca-d0a4-4399-b328-d5ece6c84c44"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{51B5A25C-13E3-4C2F-BE6F-7E06F19D34AF}"
 Languages:
 - Language: en
   Versions:
@@ -25,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f1b213ff-64b3-470d-9c81-4fa327f48662"
+      Value: "482b6d52-0e55-454a-98f9-e919c5cd3cca"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250210T154535Z
+      Value: 20250717T133909Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Indexing Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Indexing Base/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "51b5a25c-13e3-4c2f-be6f-7e06f19d34af"
+Parent: "de1aeb2d-0cbc-490b-8b25-bf46de20116c"
+Template: "de1aeb2d-0cbc-490b-8b25-bf46de20116c"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Navigation/_Indexing Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0c1ead9e-7710-439d-803f-645dab40f2ee"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133908Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "bba009d7-3b41-4634-84c9-a196cb7bbaeb"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133913Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Navigation Base.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Navigation Base.yml
@@ -3,6 +3,13 @@ ID: "e8216a0d-de33-492c-94ec-a0a06aee10e7"
 Parent: "07b61ba9-10d5-470a-8d56-0c0588aef738"
 Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Navigation/_Navigation Base"
+SharedFields:
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "dcd94e4a-9b25-4153-be9a-e8a310266001"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{F1453960-F2C4-4191-AA09-C7F77082A3A4}"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d7ba3915-cb40-42d5-9718-e4bd50faecca"
+      Value: "6e59af39-5b59-4883-a232-2ffc696902a1"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240401T201459Z
+      Value: 20250717T133921Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Navigation Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Navigation/_Navigation Base/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "f1453960-f2c4-4191-aa09-c7f77082a3a4"
+Parent: "e8216a0d-de33-492c-94ec-a0a06aee10e7"
+Template: "e8216a0d-de33-492c-94ec-a0a06aee10e7"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Navigation/_Navigation Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0b3862c6-0572-435c-865d-866b5a98e55a"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133921Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "e053d93d-9e8a-44ed-8cc0-a3635be8418c"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133927Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Article Header.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Article Header.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "c615cb0e-9f58-4751-b218-3e7cc8f11e7d"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{4576A1E1-66ED-46AA-BF69-2A1E5262CB59}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d303d5a5-bf7d-41b4-b9d3-77f948f08633"
+      Value: "c22e5c91-9dfd-470e-bc8f-57ce34937e0a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250326T174133Z
+      Value: 20250717T133937Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Article Header/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Article Header/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "4576a1e1-66ed-46aa-bf69-2a1e5262cb59"
+Parent: "0906b950-0047-4b98-93e1-cca545685259"
+Template: "0906b950-0047-4b98-93e1-cca545685259"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Article Header/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "c2db91da-17de-43d8-a726-d2f1f53f5648"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T133937Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "06f3976b-fb73-48f0-ba01-871a69656f79"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133945Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Button/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Button/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "dbbe533d-17d1-4e33-995d-6d6608ab8e77"
 Parent: "95ebaec7-3ae7-48b5-9cb4-74e5bfd6d0b6"
 Template: "95ebaec7-3ae7-48b5-9cb4-74e5bfd6d0b6"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Button/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "27c7b5cc-8bec-45aa-8aa8-c0933354e215"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240606T192503Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "4a3af4ad-b4ae-478a-b6a7-b21ca020f672"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240606T192503Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "4a3af4ad-b4ae-478a-b6a7-b21ca020f672"
+      Value: "05719224-f918-49c5-8d8b-f7873d0a4dd1"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240606T192503Z
+      Value: 20250717T133953Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Content Type/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Content Type/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "f4661afd-af46-4554-aab8-04beed561034"
 Parent: "567625b0-40bb-4fe0-9d68-6e7e4ebf9bbf"
 Template: "567625b0-40bb-4fe0-9d68-6e7e4ebf9bbf"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Content Type/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7e91b524-93ba-4b20-a02c-07dd055764d5"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "392270d0-8570-4d70-970a-349cb6380d06"
+      Value: "4006a566-f2f7-456e-b937-af95da932fd2"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T215030Z
+      Value: 20250717T134000Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Log Tab Item/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Log Tab Item/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "b90b2173-9eaf-4f6a-8246-0a0ca872df08"
 Parent: "2b90bf80-bb08-44a2-ad76-600ad0ed915b"
 Template: "2b90bf80-bb08-44a2-ad76-600ad0ed915b"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Log Tab Item/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "b3711436-1eea-4abc-8899-cd33cb23859b"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250305T184136Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "daf04b5c-cd54-491e-94e5-1f75d8b3c6dd"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "bf88958e-72a9-48a1-9348-30be4f2c86a5"
-      Hint: titleRequired
-      Value: $name
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250305T184142Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -47,14 +28,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "daf04b5c-cd54-491e-94e5-1f75d8b3c6dd"
+      Value: "13e4810f-722b-4727-9338-a1bb459c0291"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "bf88958e-72a9-48a1-9348-30be4f2c86a5"
       Hint: titleRequired
       Value: $name
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250305T184142Z
+      Value: 20250717T134009Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Logo Tab/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Logo Tab/__Standard Values.yml
@@ -10,35 +10,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{2B90BF80-BB08-44A2-AD76-600AD0ED915B}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "e2b5fccb-5cc6-48d5-8c8f-cc1adbff407d"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "121f4e8b-049b-4c7e-9f73-fddf43f4c2a9"
-      Hint: titleRequired
-      Value: $name
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240606T192503Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "fd8ccc85-712d-4a03-9bdf-9f6f09e8a8a6"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250305T184210Z
   - Version: 2
     Fields:
     - ID: "121f4e8b-049b-4c7e-9f73-fddf43f4c2a9"
@@ -57,11 +37,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fd8ccc85-712d-4a03-9bdf-9f6f09e8a8a6"
+      Value: "ac6edfaf-7067-42b2-9633-d3e688fa5cd4"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250305T184210Z
+      Value: 20250717T134017Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Person/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Person/__Standard Values.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "c9283d9e-7c29-4419-9c28-5a5c8ff53e84"
   Hint: __Bucketable
   Value: 1
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "75c654be-5790-4fb0-a052-be65d848aded"
 Languages:
 - Language: en
   Versions:
@@ -25,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "9537deb3-53f7-495c-93fc-2cd26a32e42d"
+      Value: "2aa3d44b-fe9b-4397-9cc5-51fb766fc1c9"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T223213Z
+      Value: 20250717T134027Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Text.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Text.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "d5cf15c6-369e-47f4-8d16-b783fec147d1"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{C58B3A3E-5A70-4568-825F-F0BF316EC02D}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -62,14 +68,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f6576a65-4ca4-4189-91f5-3e50f44f6363"
+      Value: "cab647a8-b980-4b7d-bddf-3bec90b03d0d"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240404T021115Z
+      Value: 20250717T134034Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Text/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Text/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "c58b3a3e-5a70-4568-825f-f0bf316ec02d"
+Parent: "58041043-7bea-44f0-b1b8-08e4ea7054f4"
+Template: "58041043-7bea-44f0-b1b8-08e4ea7054f4"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Text/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "dfac6258-8252-4bac-be3a-aef70b99b3b0"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134034Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "7a3364ca-18ca-413c-925e-cfa62da12532"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134044Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Link.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Link.yml
@@ -10,6 +10,12 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "247a0119-9c3f-454c-99b8-c66961b44e26"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{0CCCA00F-FECB-4F68-AB49-0831F684E54B}"
 Languages:
 - Language: en
   Versions:
@@ -28,11 +34,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "b9b527d6-389b-4eee-a22e-7e3cf926edcc"
+      Value: "2ded6429-3b35-46fa-a9a5-502384acd79c"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250305T204254Z
+      Value: 20250717T134059Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Link/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Link/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "0ccca00f-fecb-4f68-ab49-0831f684e54b"
+Parent: "15e94068-d790-48f2-aa56-44836ff7042a"
+Template: "15e94068-d790-48f2-aa56-44836ff7042a"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Topic Link/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "5dbcbd5e-bc77-497c-b499-01d491414d14"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134059Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "ce1f018c-5c42-4b3a-92d8-2a23a227004c"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134104Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Listing/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic Listing/__Standard Values.yml
@@ -10,35 +10,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{15E94068-D790-48F2-AA56-44836FF7042A}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "e8167a42-ea21-4d4d-ba2d-77f3756887fe"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240606T192503Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "6b22b32f-4c8b-4c6e-b004-7b762ebad3fa"
-      Hint: titleRequired
-      Value: $name
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "fd3ffd53-7ef1-4b9c-a592-60d9dd54398d"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250305T204626Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -57,11 +37,11 @@ Languages:
       Value: $name
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fd3ffd53-7ef1-4b9c-a592-60d9dd54398d"
+      Value: "68df3d27-bc7b-47e1-89f2-e289b749859b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250305T204626Z
+      Value: 20250717T134110Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Topic/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "c0b47951-98ae-46f9-89e6-81eca2a420b8"
 Parent: "7bcc6b50-ea9e-457d-b232-c5cee2090b9f"
 Template: "7bcc6b50-ea9e-457d-b232-c5cee2090b9f"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Topic/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ff805fe6-7bfc-435a-b721-7c2578506d85"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "448121fe-bed1-47ab-b382-3b8f07705efc"
+      Value: "d9d81258-4102-4d25-89ab-2558cc41c40e"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T214900Z
+      Value: 20250717T134051Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Vertical Accordion Item/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Vertical Accordion Item/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "295de4e1-da68-456e-b474-9128532c6dcd"
 Parent: "e64d342f-e5aa-4233-88c4-58ccd451a7d3"
 Template: "e64d342f-e5aa-4233-88c4-58ccd451a7d3"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/Vertical Accordion Item/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "eedea8e1-eeab-4cc1-8d63-3463a57ce7db"
 Languages:
 - Language: en
   Versions:
@@ -24,11 +31,11 @@ Languages:
       Value: $name
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "1212e01e-f81d-442f-b38c-397d12d6dd98"
+      Value: "03d85a3d-0c3e-42a6-a541-c2f80a0e53ef"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250403T132550Z
+      Value: 20250717T134118Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Vertical Image Accordion/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/Vertical Image Accordion/__Standard Values.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{E64D342F-E5AA-4233-88C4-58CCD451A7D3}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "2f53ca11-6281-4015-8a1a-3e5ebd7c4e8c"
 Languages:
 - Language: en
   Versions:
@@ -28,11 +34,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "986a9148-406e-49c1-bd36-56f8b2cbcceb"
+      Value: "a3e4109b-dde9-433f-8279-40f8239c4930"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250403T133036Z
+      Value: 20250717T134124Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Common Taxonomy Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Common Taxonomy Base/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "20c53ab2-33da-43eb-87a1-68472004058c"
 Parent: "7fb5736d-484d-47b9-9487-fa1b78cc858b"
 Template: "7fb5736d-484d-47b9-9487-fa1b78cc858b"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/_Common Taxonomy Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0c9fa79a-9ba4-4858-bcc2-817a85094759"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250303T212327Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "7eff6c24-eec8-45c0-b1ac-2c24a22d0501"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250303T212327Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "7eff6c24-eec8-45c0-b1ac-2c24a22d0501"
+      Value: "72d95d5c-4502-48c6-b583-7899a7814b0b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T212327Z
+      Value: 20250717T134138Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Image Base.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Image Base.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "8c74f7a9-a7a8-4f92-913a-a91c9ad77929"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{E5A9B265-F8BC-499A-B5AD-CD8D8F15554E}"
 Languages:
 - Language: en
   Versions:
@@ -25,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f1e02a01-3dc9-48c8-97da-e4925329ac95"
+      Value: "466d56bb-38ab-4a02-8925-7b8b6a325c54"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T202634Z
+      Value: 20250717T134144Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Image Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Image Base/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "e5a9b265-f8bc-499a-b5ad-cd8d8f15554e"
+Parent: "34ec0cfa-af55-4460-8ca4-2d36f0d9812e"
+Template: "34ec0cfa-af55-4460-8ca4-2d36f0d9812e"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/_Image Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "178c6fa7-317f-4883-b471-9435cc7b0cc1"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134144Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "3e8aeefe-cfa7-4b10-a554-8047171f9f46"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134148Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Summary Base.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Summary Base.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "92c43d0b-a25c-4cd5-b487-8fa937504c5e"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{F1CE52B1-9AAF-47D2-9011-AF486372856A}"
 Languages:
 - Language: en
   Versions:
@@ -25,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "e1c07436-8738-4f92-8e31-ae5e13197d1e"
+      Value: "a70e83ed-8156-4942-bf4b-fa1b6294967c"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250210T154046Z
+      Value: 20250717T134159Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Summary Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Summary Base/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "f1ce52b1-9aaf-47d2-9011-af486372856a"
+Parent: "281ccaa1-c247-4a28-819f-08293aa67050"
+Template: "281ccaa1-c247-4a28-819f-08293aa67050"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/_Summary Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "9da8d24e-db88-4b5b-9af1-ba53ad2493cb"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134159Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "992a60e1-6274-4ab1-b3b2-69a858cf8dc0"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134204Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Title Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Content/_Title Base/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "37da1ada-75ff-4ad8-b180-67e3b7552d05"
 Parent: "4b479b7e-b931-4bf3-8de6-b047d55a45c6"
 Template: "4b479b7e-b931-4bf3-8de6-b047d55a45c6"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Content/_Title Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "bb5bcd11-5aa4-4b0b-a0f8-35f1de84d5e7"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "8ed6880e-9301-41bd-8906-56fe5f4ef5cf"
+      Value: "968cb1c6-46a8-4bb7-8acd-0e379ae691af"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250303T210203Z
+      Value: 20250717T134209Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Header ST/PageHeaderST.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Header ST/PageHeaderST.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 50
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "5ac95568-89d2-49a4-8362-718751030dc1"
+  Value: "bca6aa1c-f43a-4996-816e-a54bedceccef"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{7B2A8AA9-D346-4EC0-8348-5D51004B4090}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -61,14 +64,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "27e105dd-3724-46a6-852c-65efb5cdd324"
+      Value: "6091b1cd-5c35-4e65-99c4-d6729fbe1728"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250523T081236Z
+      Value: 20250717T134218Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Header ST/PageHeaderST/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Header ST/PageHeaderST/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "7b2a8aa9-d346-4ec0-8348-5d51004b4090"
+Parent: "c2dc5c8b-6b22-4bb3-bdc5-01bfc65e3c53"
+Template: "c2dc5c8b-6b22-4bb3-bdc5-01bfc65e3c53"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Page Header ST/PageHeaderST/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "4d4ed1b5-78a0-412d-9a66-e08889674400"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134218Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "73bc5137-b3b4-43ce-b72e-452d7f6e2586"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134223Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Headers/Hero/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Page Headers/Hero/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "e74c975b-86ce-4578-a0ca-fec5656aeb22"
 Parent: "a19c3230-c5ee-47a1-ae3f-12a1fc3c4273"
 Template: "a19c3230-c5ee-47a1-ae3f-12a1fc3c4273"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Page Headers/Hero/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "27458191-4795-4f58-be6b-7e99ca02e7ff"
 Languages:
 - Language: en
   Versions:
@@ -24,14 +31,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "c29bbfab-cd44-4912-86fd-44001638570a"
+      Value: "a374e48f-0649-4ecc-9c07-0b92034b38d7"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250130T203127Z
+      Value: 20250717T134232Z
     - ID: "e2223200-5161-4e5a-9a35-9a5ac126c05c"
       Hint: descriptionOptional
       Value: Description Text

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Product/Product Listing/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Product/Product Listing/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "dfa396f4-ec94-4311-9599-72cea2bb0d54"
 Parent: "46d29149-02ab-4ef1-af37-e765e26a7e2f"
 Template: "46d29149-02ab-4ef1-af37-e765e26a7e2f"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Product/Product Listing/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "5469e400-a7d9-4f70-b2fe-3e7247d6fca6"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250319T172123Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "1f8caac0-c3d2-469d-b87a-9671e7b6b6b1"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d5b23eab-5eda-481f-8aa5-f81df32cc446"
-      Hint: title
-      Value: $name
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250319T172127Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -47,14 +28,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "1f8caac0-c3d2-469d-b87a-9671e7b6b6b1"
+      Value: "b74a15fb-8063-4796-ade6-c1b85d53420c"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d5b23eab-5eda-481f-8aa5-f81df32cc446"
       Hint: title
       Value: $name
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250319T172127Z
+      Value: 20250717T134246Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo Folder/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo Folder/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{BD372D9D-6E4F-4AE9-A54C-DBC2ACDEBE2A}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "e28fd68b-25a6-4288-b5fd-9734769e9226"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240426T201657Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "2505edae-0b38-46a3-b88f-60ce5b189c45"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250220T201653Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "2505edae-0b38-46a3-b88f-60ce5b189c45"
+      Value: "fe1ba4d1-0973-4735-9ce9-02d11e4f4315"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250220T201653Z
+      Value: 20250717T132800Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo/__Standard Values.yml
@@ -3,44 +3,27 @@ ID: "787dff86-1414-4260-9d94-830646318d97"
 Parent: "bd372d9d-6e4f-4ae9-a54c-dbc2acdebe2a"
 Template: "bd372d9d-6e4f-4ae9-a54c-dbc2acdebe2a"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/AnimatedPromo/__Standard Values"
+SharedFields:
+- ID: "a4f985d9-98b3-4b52-aaaf-4344f6e747c6"
+  Hint: __Workflow
+  Value: 
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "96ab1418-d345-473a-950d-05c88c48662c"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250214T165012Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "84a2a397-786e-43bd-85a0-bfbcc51fc3f3"
-      Hint: image
-      Value: |
-        <image mediaid="{567F4754-89CD-4DD9-9033-8D6E29B806C7}" />
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "529e676a-4c87-4a9d-b1f0-5391bbb2a545"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250220T201652Z
-    - ID: "da7db0f2-08eb-47c5-af07-ed12a1e998db"
-      Hint: title
-      Value: $name
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20250214T165012Z
+    - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
+      Hint: __Workflow state
+      Value: 
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -55,14 +38,14 @@ Languages:
         <image mediaid="{567F4754-89CD-4DD9-9033-8D6E29B806C7}" />
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "529e676a-4c87-4a9d-b1f0-5391bbb2a545"
+      Value: "8a3350e8-6499-48c4-96e8-e9731f196953"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250220T201652Z
+      Value: 20250717T132745Z
     - ID: "da7db0f2-08eb-47c5-af07-ed12a1e998db"
       Hint: title
       Value: $name

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/CTA Banner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/CTA Banner/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "5ef9a029-c48f-4b06-a0d5-6ec51e9dc257"
 Parent: "bee4869d-b588-42c2-9797-76510c397e6a"
 Template: "bee4869d-b588-42c2-9797-76510c397e6a"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/CTA Banner/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "88558bcc-96d7-46e9-be0b-929196593fbc"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250212T220348Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "7f025b4c-9d95-492a-9dc5-ea11ec737bbb"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250212T220348Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "7f025b4c-9d95-492a-9dc5-ea11ec737bbb"
+      Value: "8b0b0fdc-d5dd-41f3-9903-edf3083a58a3"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250212T220348Z
+      Value: 20250717T132858Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromo/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromo/__Standard Values.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{F94C8C17-70E8-4D8B-9D35-D0465C0E0945}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "2c0294fe-e9ca-4119-8e26-6a6c3ac040e8"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240426T201657Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "52805380-9ec1-4bb2-aafb-7ff942dd35c9"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250214T163639Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "52805380-9ec1-4bb2-aafb-7ff942dd35c9"
+      Value: "bf8aa7c3-efee-4070-bc11-9a0fe4e27780"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250214T163639Z
+      Value: 20250717T132907Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoItem.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoItem.yml
@@ -3,3 +3,36 @@ ID: "23ed9b63-e637-4be7-850d-2b7d45d80da9"
 Parent: "7c9ab090-cc7b-4945-ac43-7c47c57818e0"
 Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/MultiPromoItem"
+SharedFields:
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "6d434ace-c87a-42f7-a00d-8be8653e8b76"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{585D46F6-5024-4504-8FB9-741B777B59B5}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T132957Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "64268d97-6aea-4073-8414-c12ee0460313"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T132957Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoItem/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "585d46f6-5024-4504-8fb9-741b777b59b5"
+Parent: "23ed9b63-e637-4be7-850d-2b7d45d80da9"
+Template: "23ed9b63-e637-4be7-850d-2b7d45d80da9"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/MultiPromoItem/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "d262a16e-3ffb-4e77-834f-22a2858ec8f9"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T132957Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "9553135c-1776-43ee-9383-037efa3fe708"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T133003Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoTabs/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/MultiPromoTabs/__Standard Values.yml
@@ -7,38 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{CCEA3863-E5CC-4C75-8296-5B5CA47010FA}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "991d3064-8c70-4ccf-8ba0-f8818721c870"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "0b4b904d-19fa-4af3-92a7-3b4ee329f0ee"
-      Hint: title
-      Value: $name
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240426T201657Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "942ca55f-d65e-41a0-9d21-47db099d8fb0"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d2df817c-ce29-4af7-86d3-b121f5c8fb5e"
-      Hint: droplistLabel
-      Value: $name
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250218T214228Z
   - Version: 2
     Fields:
     - ID: "0b4b904d-19fa-4af3-92a7-3b4ee329f0ee"
@@ -57,14 +34,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "942ca55f-d65e-41a0-9d21-47db099d8fb0"
+      Value: "90c1a79e-ec8c-4bb5-8411-57874398d1b1"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d2df817c-ce29-4af7-86d3-b121f5c8fb5e"
       Hint: droplistLabel
       Value: $name
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250218T214228Z
+      Value: 20250717T133011Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/PromoTabItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/PromoTabItem/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "2f8685a0-0ab6-4c96-a7b2-15da418e4844"
 Parent: "ccea3863-e5cc-4c75-8296-5b5ca47010fa"
 Template: "ccea3863-e5cc-4c75-8296-5b5ca47010fa"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/PromoTabItem/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0cd1bd32-866b-41e5-8db6-709f3acd7c65"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250218T210759Z
-    - ID: "2c13f52a-6d13-4688-92f7-ecafe6c718e9"
-      Hint: title
-      Value: $name
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "cb363db8-5d8e-45a7-9704-235caca07745"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250218T211007Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -50,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "cb363db8-5d8e-45a7-9704-235caca07745"
+      Value: "fa340337-c491-4eea-ad2f-8bad18379471"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250218T211007Z
+      Value: 20250717T133024Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/SimplePromo/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/SimplePromo/__Standard Values.yml
@@ -3,39 +3,16 @@ ID: "bde3dd92-5e3e-4c1a-8666-f3ee4f488884"
 Parent: "f94c8c17-70e8-4d8b-9d35-d0465c0e0945"
 Template: "f94c8c17-70e8-4d8b-9d35-d0465c0e0945"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/SimplePromo/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "466cddc2-7e6c-423e-87f0-18497b452e76"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250214T165012Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5c33f772-5806-4ad8-a236-730f1b299531"
-      Hint: heading
-      Value: $name
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "7eca61ae-f0c1-49e6-b131-686ab895a1dc"
-      Hint: image
-      Value: |
-        <image mediaid="{567F4754-89CD-4DD9-9033-8D6E29B806C7}" />
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "5cf2b3f7-9084-4110-908c-b55545684149"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250214T165434Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -58,11 +35,11 @@ Languages:
         <image mediaid="{567F4754-89CD-4DD9-9033-8D6E29B806C7}" />
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "5cf2b3f7-9084-4110-908c-b55545684149"
+      Value: "6d3e171c-0ba2-4e92-995e-b3b7e05dbbe5"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250214T165434Z
+      Value: 20250717T133035Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/Subscription Banner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/Subscription Banner/__Standard Values.yml
@@ -3,6 +3,13 @@ ID: "28573553-a75e-4b2e-9689-6d59b2ccd3f8"
 Parent: "d2c0babb-51e4-4e13-9305-6a1107962413"
 Template: "d2c0babb-51e4-4e13-9305-6a1107962413"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/Subscription Banner/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7386c8d7-874a-4a01-9ad4-fa41146114a1"
 Languages:
 - Language: en
   Versions:
@@ -21,14 +28,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "c25b0228-fa44-418b-ac89-cd858f77c602"
+      Value: "ad6487e1-efbc-43fc-9fb0-2a996a02f1b5"
     - ID: "a823205f-7781-42e2-914c-2b9b0e65161f"
       Hint: titleRequired
       Value: $name
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250326T151547Z
+      Value: 20250717T133052Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/TestimonialCarousel/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/TestimonialCarousel/__Standard Values.yml
@@ -7,27 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{A2DBD4D1-E6DB-49EF-A759-FD4F765227AA}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "a6d11551-e505-4486-8c4a-e60f2816bcf4"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20111206T092520Z
-    - ID: "872c7094-2de6-4934-8b6c-1f9f6c58721b"
-      Hint: Title
-      Value: $name
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "ddb90a25-238c-43aa-9ab9-e6773853fa58"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250221T183951Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -38,11 +26,11 @@ Languages:
       Value: $name
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ddb90a25-238c-43aa-9ab9-e6773853fa58"
+      Value: "cee150e8-d3bc-4131-ad15-5f8c1b868041"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250221T183951Z
+      Value: 20250717T133059Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/TestimonialItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/TestimonialItem/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "f72b924c-78ef-4e0b-a8a2-396987dfec76"
 Parent: "a2dbd4d1-e6db-49ef-a759-fd4f765227aa"
 Template: "a2dbd4d1-e6db-49ef-a759-fd4f765227aa"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Promos/TestimonialItem/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "e8a6d783-9851-470e-88bd-25e2fcc70c89"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250221T183733Z
-    - ID: "50747140-92d9-4912-83f4-8cfd2e251ba1"
-      Hint: testimonialQuote
-      Value: $name
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "0dd6aaf1-fcdf-4f8c-a1f0-f9496eeca01e"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250221T184029Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -50,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "0dd6aaf1-fcdf-4f8c-a1f0-f9496eeca01e"
+      Value: "693ee83e-8d8f-4989-96a3-23e66c8f9ba3"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250221T184029Z
+      Value: 20250717T133106Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Open Graph Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Open Graph Base/__Standard Values.yml
@@ -3,35 +3,16 @@ ID: "0fa5c2a2-9285-4926-b82a-ab6cd0a1dbcb"
 Parent: "2cf67cde-ea27-425d-95d1-1da80a507abd"
 Template: "2cf67cde-ea27-425d-95d1-1da80a507abd"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Site Metadata/_Open Graph Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "93c79e67-c1b8-45f9-a617-949631bd4025"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250210T155449Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "e29f8d47-7067-4898-9c01-ebe5dc950274"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250210T155453Z
-    - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
-      Hint: ogTitle
-      Value: $name
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -47,14 +28,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "e29f8d47-7067-4898-9c01-ebe5dc950274"
+      Value: "8cefde88-2dcc-4550-acd1-62639cbaeb9a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250210T155453Z
+      Value: 20250717T134255Z
     - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
       Hint: ogTitle
       Value: $name

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Site Metadata.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Site Metadata.yml
@@ -3,6 +3,13 @@ ID: "f43e275a-48d0-4a45-8313-862f81be33ce"
 Parent: "ce2915f1-9928-4e33-833d-352bfb0d3157"
 Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Site Metadata/_Site Metadata"
+SharedFields:
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0ba35638-8ae7-4366-961d-957cc215cf72"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{546B197D-50E8-4833-B00E-E08EABDA7ECB}"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "c0cf87e0-05c2-4912-a86a-bae2cb3c352b"
+      Value: "351fa0d1-2d79-4762-a746-ed4e4d6f1314"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240403T204904Z
+      Value: 20250717T134302Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Site Metadata/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Site Metadata/_Site Metadata/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "546b197d-50e8-4833-b00e-e08eabda7ecb"
+Parent: "f43e275a-48d0-4a45-8313-862f81be33ce"
+Template: "f43e275a-48d0-4a45-8313-862f81be33ce"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Site Metadata/_Site Metadata/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7b15a26d-2254-4fd9-8ed2-3f8b08014dbd"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134302Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "54980a58-8ec8-493a-9c74-3c3277c94d65"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134307Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonial.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonial.yml
@@ -15,6 +15,12 @@ SharedFields:
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "00f54c31-fe7d-4724-8b26-01f5818c86b1"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{F82CED6C-6421-494B-84BF-86573A8F32FF}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -58,14 +64,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "6b98e36a-2702-492f-a1af-02a1dbe0ce57"
+      Value: "b8e9c9da-dda5-4250-ac79-4c8038424d6a"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\richard.seal@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250216T143154Z
+      Value: 20250717T134321Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonial/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonial/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "f82ced6c-6421-494b-84bf-86573a8f32ff"
+Parent: "fd50ad08-3773-4ad8-afe7-a2c3dc34aff0"
+Template: "fd50ad08-3773-4ad8-afe7-a2c3dc34aff0"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Testimonials/Customer Testimonial/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "771f6290-d0e9-4954-8d4a-462070fedbcc"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T134321Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "345ef9cc-c500-438c-9388-ec92ce80245d"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T134328Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonials Slider/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Testimonials/Customer Testimonials Slider/__Standard Values.yml
@@ -7,6 +7,12 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{FD50AD08-3773-4AD8-AFE7-A2C3DC34AFF0}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "34b43abd-d7be-4051-87af-9a9d553a6c82"
 Languages:
 - Language: en
   Versions:
@@ -17,11 +23,11 @@ Languages:
       Value: 20111206T092520Z
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "e86fc02c-c9d7-45bd-9143-e8c0e75f7980"
+      Value: "d8ab0cde-1674-4fe4-bbea-9348df803039"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\richard.seal@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250213T213138Z
+      Value: 20250717T134359Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Presentation/Enumeration/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Presentation/Enumeration/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "bc32036d-0619-423a-a42a-254ce4b01b8e"
 Parent: "83746e54-66fe-4fd4-b79d-ff3fd4acd903"
 Template: "83746e54-66fe-4fd4-b79d-ff3fd4acd903"
 Path: "/sitecore/templates/Project/click-click-launch/Presentation/Enumeration/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "55f4b360-5ee1-4d95-8f81-2fae85126bac"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240320T172243Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "185827dc-99c4-4ea5-98ac-fbd4ba582c00"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20240320T172243Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "185827dc-99c4-4ea5-98ac-fbd4ba582c00"
+      Value: "54fb76fa-d0e6-441e-bf7a-85b1e6d9d379"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20240320T172243Z
+      Value: 20250717T134946Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Signup Banner/SignupBanner.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Signup Banner/SignupBanner.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 50
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "b6c6ed34-b7df-4a95-ac29-9f9dcb505aac"
+  Value: "19f90d6c-b589-4907-a419-e9ca28a05963"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{9633E8F8-24C1-4E24-A6C6-FFE792AEB996}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -61,14 +64,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "5f444b07-d6d1-4e11-9d85-067cfd959027"
+      Value: "21baea55-9a02-4023-b197-fe3d3e9d042e"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\chamodi.samarawickrama@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250523T145900Z
+      Value: 20250717T135004Z
 - Language: "ja-JP"
   Fields:
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Signup Banner/SignupBanner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Signup Banner/SignupBanner/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "9633e8f8-24c1-4e24-a6c6-ffe792aeb996"
+Parent: "3766e92a-e97f-4118-91a0-06223312a461"
+Template: "3766e92a-e97f-4118-91a0-06223312a461"
+Path: "/sitecore/templates/Project/click-click-launch/Signup Banner/SignupBanner/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ee1821c6-7b05-4a42-8975-1417f81fe9bb"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135004Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "852adf62-9461-416d-be8d-6b0039217c32"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135009Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Page/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Page/__Standard Values.yml
@@ -10,40 +10,26 @@ SharedFields:
     {AC9DE9BE-8E86-4147-8FBC-739D5560408B}
     {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
     {1B76AF75-DD75-450C-92E3-FF0F339F490B}
+- ID: "a4f985d9-98b3-4b52-aaaf-4344f6e747c6"
+  Hint: __Workflow
+  Value: 
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{B4F49B23-4BBA-4C79-BA22-F89F5F0D4E4F}"
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "59f2ccf9-a7e1-41f8-a51a-bc4afa496df5"
+  Value: "ab7bade7-0965-4eaf-a4a6-4256281b0c21"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240304T202210Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "b021b074-b39e-4f14-992a-b072d71ed777"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\richard.seal@sitecore.com
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250529T031802Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20240304T202210Z
+    - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
+      Hint: __Workflow state
+      Value: 
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -54,11 +40,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f92b06d0-afaf-4234-b16c-a3d5a0d9d8b8"
+      Value: "cff7109b-b258-421d-8281-0e80f738aff4"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250603T052033Z
+      Value: 20250717T135829Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FeatureBanner/FeatureBanner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FeatureBanner/FeatureBanner/__Standard Values.yml
@@ -7,35 +7,15 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: "{4507E405-6110-4E56-AF58-27B65B58268F}"
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "b8a66080-0ddc-4974-b6bb-00f226ae2bbc"
+  Value: "c1dfe8f4-528c-477a-a9b7-32521e512187"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20240426T201657Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "52805380-9ec1-4bb2-aafb-7ff942dd35c9"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250214T163639Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -51,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "8ba62daf-509d-41d0-bafc-6a48b27fb89d"
+      Value: "560532ed-bc44-4140-ac90-93c6d20b0934"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250602T125127Z
+      Value: 20250717T135032Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FeatureBanner/FeatureItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FeatureBanner/FeatureItem/__Standard Values.yml
@@ -3,39 +3,16 @@ ID: "80125cd6-8a4d-435f-b2de-bc40afc398ac"
 Parent: "4507e405-6110-4e56-af58-27b65b58268f"
 Template: "4507e405-6110-4e56-af58-27b65b58268f"
 Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/FeatureBanner/FeatureItem/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "aaa9ddd9-901f-4b8f-8b02-a5ec5f3f8cea"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "21aae250-ac81-46a1-a336-29a030bfc511"
-      Hint: heading
-      Value: $name
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250214T165012Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "5cf2b3f7-9084-4110-908c-b55545684149"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250214T165434Z
-    - ID: "f8f97c78-419a-431b-82e7-e46a39c7393f"
-      Hint: image
-      Value: |
-        <image mediaid="{567F4754-89CD-4DD9-9033-8D6E29B806C7}" />
   - Version: 2
     Fields:
     - ID: "21aae250-ac81-46a1-a336-29a030bfc511"
@@ -54,14 +31,14 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "03e99263-e86e-49cb-80f8-abca755b188b"
+      Value: "57861498-4b73-4d09-a151-fd50335c6fcc"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250602T125127Z
+      Value: 20250717T135050Z
     - ID: "f8f97c78-419a-431b-82e7-e46a39c7393f"
       Hint: image
       Value: |

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FooterST/FooterST.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FooterST/FooterST.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "87dd003b-6285-42a6-acd4-095efd163cbd"
+  Value: "3fee9237-156b-441a-b45a-8fa9e9699a04"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{992F1D36-59FA-470A-BB2B-09EB404DD495}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "d8d10532-9fe8-475e-a2d7-668f3d4c1383"
+      Value: "fa8fc5f1-5c89-488b-bcef-8f7032c88ded"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250529T074509Z
+      Value: 20250717T135058Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FooterST/FooterST/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/FooterST/FooterST/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "992f1d36-59fa-470a-bb2b-09eb404dd495"
+Parent: "92979eba-bd00-422e-b295-3d8dadca860d"
+Template: "92979eba-bd00-422e-b295-3d8dadca860d"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/FooterST/FooterST/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "22d8d1dc-d79b-4b99-9ae7-9523df08d283"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135058Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "2d25c40b-62a6-4766-a745-ea09e3dbbc72"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135103Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/HeaderST/HeaderST.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/HeaderST/HeaderST.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "7587a183-b418-446d-be41-925eee6d4bfe"
+  Value: "34e205f9-468c-4738-949e-754cce4a6df3"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{7BE2650D-8717-4E63-B1B3-ABA71764A900}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fdd43424-2b2d-46e0-b9f1-299c921f747a"
+      Value: "807fc916-dd70-4bb9-912f-73a51db03eda"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250612T090717Z
+      Value: 20250717T135116Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/HeaderST/HeaderST/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/HeaderST/HeaderST/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "7be2650d-8717-4e63-b1b3-aba71764a900"
+Parent: "3cb38973-6209-4407-b463-4b017e0467cd"
+Template: "3cb38973-6209-4407-b463-4b017e0467cd"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/HeaderST/HeaderST/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "12405cdf-b8fd-49b4-8984-31c7d8569488"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135115Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "0e996ced-c515-4fa6-8cd5-e2ca95b0ff95"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135120Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ImageBanner/ImageBanner.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ImageBanner/ImageBanner.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "2d06ad50-dd08-4c00-9e23-c86c92667070"
+  Value: "37d13b6b-93be-4c7c-84d8-b6d833719494"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{99BD4BAA-95F3-4A5D-9838-3F2478778327}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "00274430-e506-406b-9a3e-6681d8123e94"
+      Value: "168f6995-ee4c-4e82-be71-c70ed22b66f0"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T130347Z
+      Value: 20250717T135132Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ImageBanner/ImageBanner/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ImageBanner/ImageBanner/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "99bd4baa-95f3-4a5d-9838-3f2478778327"
+Parent: "b754cb40-d82d-46e5-b001-e7f4434fd399"
+Template: "b754cb40-d82d-46e5-b001-e7f4434fd399"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/ImageBanner/ImageBanner/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "c1a63be2-588a-4753-8b8e-e1a7ad540bdd"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135132Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "9945e024-b189-4ccc-81d1-cb0144ce03c0"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135136Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/MegaMenuItem/MegaMenuItem.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/MegaMenuItem/MegaMenuItem.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "66dce0fb-16e9-48f1-bd4f-88c6c908e64a"
+  Value: "f86b6a48-8799-4993-a7f1-53eb1b05bf3f"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{FAB39D0D-324B-4893-839E-87689725498F}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "19f8e3be-d595-447c-9b8f-cf783a2ae4a6"
+      Value: "7c14bfb0-3e80-489f-8b8b-f67da0fdb0fe"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250612T094727Z
+      Value: 20250717T135146Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/MegaMenuItem/MegaMenuItem/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/MegaMenuItem/MegaMenuItem/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "fab39d0d-324b-4893-839e-87689725498f"
+Parent: "6fe9f9e9-5ecb-4333-b270-326b701b5352"
+Template: "6fe9f9e9-5ecb-4333-b270-326b701b5352"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/MegaMenuItem/MegaMenuItem/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "faf09be7-c3db-4c6f-99af-21ae70d955b8"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135146Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "e0eba08a-38d9-4cc9-a646-1cf92d081b65"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135151Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ProductComparison/ProductComparison.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ProductComparison/ProductComparison.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "6acf6914-9f4c-408d-8b69-00806c798b31"
+  Value: "1198a897-afb7-44e9-9699-ae68548ffc0d"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{4DFE86C6-7FE7-4B8C-8F61-3D461C4966FB}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "f6b11be6-55b3-4ee6-bddf-e813a1bd6a7b"
+      Value: "453a501c-b711-4fc8-91d0-aba8218e20d3"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250604T083537Z
+      Value: 20250717T135201Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ProductComparison/ProductComparison/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/ProductComparison/ProductComparison/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "4dfe86c6-7fe7-4b8c-8f61-3d461c4966fb"
+Parent: "6589a92d-1e47-457d-8cc1-d37d5868b89d"
+Template: "6589a92d-1e47-457d-8cc1-d37d5868b89d"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/ProductComparison/ProductComparison/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "328f1199-63e8-460e-b934-0dc81c3f948a"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135201Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "24be2cdf-dae6-4eb1-98bb-d59a05357eaa"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135206Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/TextSlider/TextSlider.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/TextSlider/TextSlider.yml
@@ -17,7 +17,10 @@ SharedFields:
   Value: 100
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "4aa0b93a-412f-49ca-83a0-068ff5a39d58"
+  Value: "b0e93283-22db-46ee-811a-3cf758989716"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{4A4844C0-ED2E-4472-AA0E-C765A513C710}"
 Languages:
 - Language: "de-DE"
   Fields:
@@ -71,14 +74,14 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "c6840eca-aead-4838-bf93-e69ffef5628d"
+      Value: "49c13136-262b-4b0f-8dd4-cef096fffb17"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250529T032728Z
+      Value: 20250717T135220Z
 - Language: "ja-JP"
   Fields:
   - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/TextSlider/TextSlider/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Sites/Site 3/TextSlider/TextSlider/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "4a4844c0-ed2e-4472-aa0e-c765a513c710"
+Parent: "bf764c63-df4b-460f-bf87-b4f16733a4fd"
+Template: "bf764c63-df4b-460f-bf87-b4f16733a4fd"
+Path: "/sitecore/templates/Project/click-click-launch/Sites/Site 3/TextSlider/TextSlider/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "f22de73f-cc66-42be-aebb-1a4cf2f4c025"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135220Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "dcc84292-6d4b-49ae-a22c-adbf2b2886b8"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135225Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Content Type/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Content Type/__Standard Values.yml
@@ -3,32 +3,16 @@ ID: "f7a55c6b-79f4-421a-98a0-445fe69a1365"
 Parent: "a97e3c2d-727a-4703-9eae-8d21b200953d"
 Template: "a97e3c2d-727a-4703-9eae-8d21b200953d"
 Path: "/sitecore/templates/Project/click-click-launch/Taxonomy/Content Type/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "0d8cd919-cd7d-4e63-a715-e61a2f47492b"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250317T173247Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "39cdaf29-daaf-48ab-9fbb-164850a60491"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250317T173247Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -44,11 +28,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "39cdaf29-daaf-48ab-9fbb-164850a60491"
+      Value: "76453eee-8e84-4a32-a34d-60f052b0329b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250317T173247Z
+      Value: 20250717T135239Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Topic.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Topic.yml
@@ -12,6 +12,12 @@ SharedFields:
   Value: |
     {1930BBEB-7805-471A-A3BE-4858AC7CF696}
     {2EE99FFD-A9B7-4D5C-A684-D1AFC8F78087}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "d1ccd78b-756a-4620-b22c-c6022450867f"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{5B2BF4E7-20B2-4D89-B434-3C5B2DC7268E}"
 Languages:
 - Language: en
   Versions:
@@ -30,11 +36,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "791ecc8e-53b4-4a57-a737-6aa654a15227"
+      Value: "37c0e5c3-125c-449d-afb0-936f8496f766"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250317T173020Z
+      Value: 20250717T135245Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Topic/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/Topic/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "5b2bf4e7-20b2-4d89-b434-3c5b2dc7268e"
+Parent: "b26a9c54-47e8-4db1-9222-8d93f026d610"
+Template: "b26a9c54-47e8-4db1-9222-8d93f026d610"
+Path: "/sitecore/templates/Project/click-click-launch/Taxonomy/Topic/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "b757b85d-6ef5-47b4-8fd0-6db03805acf5"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135245Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "aeaafee5-1c68-45ec-b9a3-67efd5020de3"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135249Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/_Taxonomy Item Base.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/_Taxonomy Item Base.yml
@@ -7,32 +7,15 @@ SharedFields:
 - ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
   Hint: __Base template
   Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "b80c9512-f208-4b62-94a4-28e4c4dd8479"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{9A17FBEB-A35E-4386-9403-22A514A45211}"
 Languages:
 - Language: en
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250317T172247Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "0f97a67e-646c-48f0-b340-03348d35b11a"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250317T172305Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -48,11 +31,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "0f97a67e-646c-48f0-b340-03348d35b11a"
+      Value: "690e83c7-829b-4d84-91ec-9bc4145f3227"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\Admin
+        sitecore\anton.kechashin@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250317T172305Z
+      Value: 20250717T135255Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/_Taxonomy Item Base/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Taxonomy/_Taxonomy Item Base/__Standard Values.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "9a17fbeb-a35e-4386-9403-22a514a45211"
+Parent: "2ee99ffd-a9b7-4d5c-a684-d1afc8f78087"
+Template: "2ee99ffd-a9b7-4d5c-a684-d1afc8f78087"
+Path: "/sitecore/templates/Project/click-click-launch/Taxonomy/_Taxonomy Item Base/__Standard Values"
+SharedFields:
+- ID: "ca9b9f52-4fb0-4f87-a79f-24dea62cda65"
+  Hint: __Default workflow
+  Value: "{A053ED9F-4099-4682-9411-2B4C98E481E4}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "27e04b72-21ad-4d69-a0a3-b8a70d02fafc"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250717T135255Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "366eaa71-1b1d-46b1-8f2b-664698938e02"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\anton.kechashin@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250717T135259Z


### PR DESCRIPTION
Added the `Default Datasource Workflow` as a default workflow for the datasource items under these folders:
- /sitecore/templates/Project/click-click-launch/Components
- /sitecore/templates/Project/click-click-launch/Presentation
- /sitecore/templates/Project/click-click-launch/Signup Banner
- /sitecore/templates/Project/click-click-launch/Sites
- /sitecore/templates/Project/click-click-launch/Taxonomy

**Note:** the "Folder" templates were skipped (such as Accordion Folder, Text Banner Folder etc).

Added the `Default Workflow` as a default workflow for the `/sitecore/templates/Project/click-click-launch/Site/Page` template.

**Note:** the Home page will not be in the Draft state after the site creation. Every other page will be. This is related to the site creation process. The Home page is first created from the Base Page template and then it is changed to the Home Page template of the site collection.