### PR TITLE
[Futuristic-drive] Ensure default placeholder and button text render

### DIFF
--- a/examples/kit-nextjs-location-finder/src/components/forms/zipcode/ZipcodeSearchForm.dev.tsx
+++ b/examples/kit-nextjs-location-finder/src/components/forms/zipcode/ZipcodeSearchForm.dev.tsx
@@ -49,8 +49,8 @@ interface ZipcodeSearchFormProps {
 export const Default: React.FC<ZipcodeSearchFormProps> = ({
   onSubmit = (values) => console.log(values),
   defaultZipcode = '',
-  buttonText = 'Find Availability',
-  placeholder = 'Enter your zip code',
+  buttonText,
+  placeholder,
 }) => {
   const form = useForm<ZipcodeFormValues>({
     resolver: zodResolver(zipcodeFormSchema),
@@ -77,14 +77,14 @@ export const Default: React.FC<ZipcodeSearchFormProps> = ({
               <FormItem className="min-w-51 mt-0 flex-shrink basis-64 space-y-0">
                 <FormLabel className="sr-only">Enter your zip code</FormLabel>
                 <FormControl>
-                  <Input type="tel" placeholder={placeholder} {...field} />
+                  <Input type="tel" placeholder={placeholder || 'Enter your zip code'} {...field} />
                 </FormControl>
                 <FormMessage className="absolute top-[100%] pt-1 text-[#ff5252]" />
               </FormItem>
             )}
           />
           <Button type="submit" className="flex-shrink-0">
-            {buttonText}
+            {buttonText || 'Find Availability'}
           </Button>
         </form>
       </div>

--- a/examples/kit-nextjs-location-finder/src/components/ui/navigation-menu.tsx
+++ b/examples/kit-nextjs-location-finder/src/components/ui/navigation-menu.tsx
@@ -25,11 +25,11 @@ const NavigationMenuList = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
 >(({ className, ...props }, ref) => (
   <>
-    <div className="pointer-events-none absolute inset-0 -z-10">
+    <div className="absolute -translate-y-3">
       <NavigationMenuPrimitive.List
         ref={ref}
         className={cn(
-          'group flex flex-1 list-none items-center justify-center space-x-1 pointer-events-auto',
+          'group flex flex-1 list-none items-center justify-center space-x-1',
           className
         )}
         {...props}
@@ -109,7 +109,7 @@ const NavigationMenuIndicator = React.forwardRef<
     )}
     {...props}
   >
-    <div className="pointer-events-none bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+    <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
   </NavigationMenuPrimitive.Indicator>
 ));
 NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;


### PR DESCRIPTION
Fixes an issue where placeholder and buttonText props were not rendered on the live site due to empty or undefined CMS values