### PR TITLE
Fix background image display in Bold site footer

### DIFF
--- a/examples/kit-nextjs-product-listing/src/components/site-three/FooterST.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/site-three/FooterST.tsx
@@ -28,7 +28,7 @@ export const Default = (props: FooterSTProps) => {
   return (
     <section
       className={`relative bg-primary pt-16 lg:pt-30 pb-8 bg-cover bg-center ${props.params.styles}`}
-      style={{ backgroundImage: 'url("./footer-texture.webp")' }}
+      style={{ backgroundImage: 'url("/footer-texture.webp")' }}
       data-class-change
     >
       <div className="container mx-auto px-4">
@@ -75,7 +75,7 @@ export const LogoLeft = (props: FooterSTProps) => {
   return (
     <section
       className={`relative bg-primary pt-16 lg:pt-30 bg-cover bg-center ${props.params.styles}`}
-      style={{ backgroundImage: 'url("./footer-texture.webp")' }}
+      style={{ backgroundImage: 'url("/footer-texture.webp")' }}
       data-class-change
     >
       <div className="container mx-auto px-4">
@@ -124,7 +124,7 @@ export const LogoRight = (props: FooterSTProps) => {
   return (
     <section
       className={`relative bg-primary pb-8 bg-cover bg-center ${props.params.styles}`}
-      style={{ backgroundImage: 'url("./footer-texture.webp")' }}
+      style={{ backgroundImage: 'url("/footer-texture.webp")' }}
       data-class-change
     >
       <div className="h-10 lg:h-20 bg-sound-waves bg-[length:auto_200%] bg-repeat bg-bottom bg-center-x mb-12 lg:mb-16"></div>
@@ -173,7 +173,7 @@ export const Centered = (props: FooterSTProps) => {
   return (
     <section
       className={`relative bg-primary py-8 lg:py-20 bg-cover bg-center ${props.params.styles}`}
-      style={{ backgroundImage: 'url("./footer-texture.webp")' }}
+      style={{ backgroundImage: 'url("/footer-texture.webp")' }}
       data-class-change
     >
       <div className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-20 lg:h-40 bg-sound-waves bg-contain bg-repeat bg-center filter invert opacity-75 z-10"></div>


### PR DESCRIPTION
Ensures that footer no longer looks like this on certain pages:
<img width="1877" height="1098" alt="image" src="https://github.com/user-attachments/assets/4e190109-f690-490b-b78f-0f835e9a4a83" />
and always looks proper:
<img width="1752" height="1106" alt="image" src="https://github.com/user-attachments/assets/60cd8bdb-21b3-4a2a-8af7-229e21fe2858" />
