### PR TITLE
[Product Listing] Repeated text in TextSlider component is not editable

### DIFF
--- a/examples/kit-nextjs-product-listing/src/components/site-three/TextSlider.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/site-three/TextSlider.tsx
@@ -1,4 +1,4 @@
-import { Text as ContentSdkText, Field } from '@sitecore-content-sdk/nextjs';
+import { Text as ContentSdkText, Field, useSitecore } from '@sitecore-content-sdk/nextjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface Fields {
@@ -11,6 +11,7 @@ type TextSliderProps = {
 };
 
 export const Default = (props: TextSliderProps) => {
+  const { page } = useSitecore();
   const containerRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLDivElement>(null);
   const [repeatCount, setRepeatCount] = useState(1);
@@ -21,6 +22,10 @@ export const Default = (props: TextSliderProps) => {
   }, [props.fields.Text?.value]);
 
   useEffect(() => {
+    if (page.mode.isEditing) {
+      return;
+    }
+
     const calculateRepeats = () => {
       if (!measureRef.current || !containerRef.current) return;
 
@@ -49,7 +54,7 @@ export const Default = (props: TextSliderProps) => {
     window.addEventListener('resize', calculateRepeats);
 
     return () => window.removeEventListener('resize', calculateRepeats);
-  }, [phrase]);
+  }, [phrase, page.mode.isEditing]);
 
   return (
     <div
@@ -64,8 +69,8 @@ export const Default = (props: TextSliderProps) => {
       >
         {phrase}
       </h2>
-
-      {ready && (
+      {/* In editing mode, we want to show the text as is */}
+      {(ready || page.mode.isEditing) && (
         <div
           className="flex absolute top-1/2 -translate-y-1/2 animate-marquee will-change-transform whitespace-nowrap uppercase"
           style={{


### PR DESCRIPTION
We decided to render a single field value in editing and in other cases make it repeatable
In edit mode repeated values cause issues with editing experience, since repeated phrases are not updated on field value change. We don't have a way to subscribe on field value update If iframe is not reloaded, so we can't resize and recalculate amount of phrases