### PR TITLE
Fix ignored component-map.ts file in Article and Location Finder starter applications

### DIFF
--- a/examples/kit-nextjs-article-starter/.gitignore
+++ b/examples/kit-nextjs-article-starter/.gitignore
@@ -26,4 +26,6 @@
 .vercel
 
 # sitecore temp files
-.sitecore
+.sitecore/*
+# except for component-map
+!.sitecore/component-map.ts

--- a/examples/kit-nextjs-location-finder/.gitignore
+++ b/examples/kit-nextjs-location-finder/.gitignore
@@ -22,6 +22,6 @@
 .vercel
 
 # sitecore temp files
-.sitecore
+.sitecore/*
 # except for component-map
 !.sitecore/component-map.ts


### PR DESCRIPTION
# Summary

This PR fixes a configuration issue in the `.gitignore` files of the **Article** and **Location Finder** starter applications.

Currently, their `.gitignore` files exclude the entire `.sitecore` folder, which unintentionally prevents the `component-map.ts` file from being tracked by Git. While this is not an issue in this repository (since the `component-map.ts` files were already committed previously), it becomes a problem when these starter applications are copied into another repository. In that scenario, the `component-map.ts` file is ignored and not committed, leading to failed deployments.

The fix updates the `.gitignore` entries to match the configuration used in other starter kit example head applications, ensuring that `component-map.ts` is properly included in version control.

# Reason for Changes

When the applications are copied into another repository with the existing `.gitignore` file:

* The `component-map.ts` file is excluded.
* On XM Cloud deployments, builds fail because the file is missing while still being referenced by other parts of the application.

This change ensures consistent behavior across all starter applications and prevents deployment failures.

# Manual Testing

1. Copied both the Article and Location Finder starter applications into another repository.
2. Verified that before the fix, the `component-map.ts` file was ignored by Git.
3. Applied the updated `.gitignore` configuration.
4. Confirmed that `component-map.ts` is now correctly tracked and included in commits.
5. Triggered an XM Cloud deployment and validated that the head applications build successfully without errors.