### PR TITLE
add missing dependency sitecore-cloudsdk/personalize package to basic-nextjs

### DIFF
--- a/examples/basic-nextjs/package.json
+++ b/examples/basic-nextjs/package.json
@@ -26,6 +26,7 @@
     "@sitecore-cloudsdk/events": "^0.5.1",
     "@sitecore-content-sdk/nextjs": "^1.0.0",
     "@sitecore-feaas/clientside": "^0.6.0",
+    "@sitecore-cloudsdk/personalize": "^0.5.4",
     "@sitecore/components": "~2.1.0",
     "bootstrap": "^5.3.6",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
This pull request adds the missing package to @sitecore-cloudsdk/personalize.

<img width="976" height="489" alt="image" src="https://github.com/user-attachments/assets/abc0b62b-e298-4e71-931d-3476531f5ffa" />
