### PR TITLE
Fix: make Title field editable via route field

### DIFF
--- a/examples/kit-nextjs-skate-park/src/components/title/Title.tsx
+++ b/examples/kit-nextjs-skate-park/src/components/title/Title.tsx
@@ -51,7 +51,7 @@ export const Default = ({ params, fields }: TitleProps): JSX.Element => {
   const link: LinkField = {
     value: {
       href: datasource?.url?.path,
-      title: titleField?.value || datasource?.field?.jsonValue?.value,
+      title: (titleField?.value ? String(titleField.value) : undefined) || datasource?.field?.jsonValue?.value
     },
   };
 


### PR DESCRIPTION
## What
Ensure the Title field rendering uses the route's Title field so that it includes the correct Experience Editor metadata (`chrometype="field"`) and is editable.

## Why
Previously, the Title component rendered the field from `contextItem`, which did not provide the required metadata. As a result, the Title was not editable in the Experience Editor. Starter templates worked, but new components added to the page were not editable.

## How
- Updated `Title.tsx` to use `page.layout.sitecore.route?.fields?.Title` instead of `contextItem`.
- Verified that the `<Text />` component now renders with EE metadata.

## Tests
- [x] Manual verification in Experience Editor
- [ ] Unit tests updated/added (if applicable)
- [ ] CI pipeline passing

## Notes
- Related ticket: [JSS-8043](https://sitecore.atlassian.net/browse/JSS-8043)
- No breaking changes
- No config changes


[JSS-8043]: https://sitecore.atlassian.net/browse/JSS-8043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ