### PR TITLE
Fix: Enable editing of Title field via route field

### DIFF
--- a/examples/kit-nextjs-article-starter/src/components/sxa/Title.tsx
+++ b/examples/kit-nextjs-article-starter/src/components/sxa/Title.tsx
@@ -37,12 +37,11 @@ type TitleProps = {
 
 export const Default = (props: TitleProps): JSX.Element => {
   const { page } = useSitecore();
-  const datasource = props.fields?.data?.datasource || props.fields?.data?.contextItem;
-  const text: TextField = datasource?.field?.jsonValue || {};
+  const titleField: TextField = page.layout.sitecore.route?.fields?.pageTitle as TextField;
   const isPageEditing = Boolean(page.mode.isEditing);
   const modifyTitleProps = {
-    ...text,
-    value: text?.value || 'Add Title',
+    ...titleField,
+    value: titleField?.value || 'Add Title',
   };
 
   if (!page.mode.isNormal) {
@@ -74,7 +73,7 @@ export const Default = (props: TitleProps): JSX.Element => {
             className="field-title"
           />
         ) : (
-          <Text tag={props.params.tag} field={text} className="field-title" />
+          <Text tag={props.params.tag} field={titleField} className="field-title" />
         )}
       </div>
     </div>

--- a/examples/kit-nextjs-location-finder/src/components/sxa/Title.tsx
+++ b/examples/kit-nextjs-location-finder/src/components/sxa/Title.tsx
@@ -56,17 +56,17 @@ export const Default = (props: TitleProps): JSX.Element => {
   const datasource = props.fields?.data?.datasource || props.fields?.data?.contextItem;
   const { page } = useSitecore();
   const { mode } = page;
-  const text: TextField = datasource?.field?.jsonValue || {};
+  const titleField: TextField = page.layout.sitecore.route?.fields?.pageTitle as TextField;
   const link: LinkField = {
     value: {
       href: datasource?.url?.path,
-      title: datasource?.field?.jsonValue?.value,
+      title: titleField?.value ? String(titleField.value) : datasource?.field?.jsonValue?.value,
     },
   };
   if (!mode.isNormal) {
     link.value.querystring = `sc_site=${datasource?.url?.siteName}`;
-    if (!text?.value) {
-      text.value = 'Title field';
+    if (!titleField?.value) {
+      titleField.value = 'Title field';
       link.value.href = '#';
     }
   }
@@ -75,10 +75,10 @@ export const Default = (props: TitleProps): JSX.Element => {
     <ComponentContent styles={props.params.styles} id={props.params.RenderingIdentifier}>
       <>
         {mode.isEditing ? (
-          <Text field={text} />
+          <Text field={titleField} />
         ) : (
           <Link field={link}>
-            <Text field={text} />
+            <Text field={titleField} />
           </Link>
         )}
       </>

--- a/examples/kit-nextjs-product-listing/src/components/sxa/Title.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/sxa/Title.tsx
@@ -56,17 +56,19 @@ export const Default = (props: TitleProps): JSX.Element => {
   const datasource = props.fields?.data?.datasource || props.fields?.data?.contextItem;
   const { page } = useSitecore();
   const { mode } = page;
-  const text: TextField = datasource?.field?.jsonValue || {};
+  const titleField: TextField = page.layout.sitecore.route?.fields?.pageTitle as TextField;
   const link: LinkField = {
     value: {
       href: datasource?.url?.path,
-      title: datasource?.field?.jsonValue?.value,
+      title:
+        (titleField?.value ? String(titleField.value) : undefined) ||
+        datasource?.field?.jsonValue?.value,
     },
   };
   if (!mode.isNormal) {
     link.value.querystring = `sc_site=${datasource?.url?.siteName}`;
-    if (!text?.value) {
-      text.value = 'Title field';
+    if (!titleField?.value) {
+      titleField.value = 'Title field';
       link.value.href = '#';
     }
   }
@@ -75,10 +77,10 @@ export const Default = (props: TitleProps): JSX.Element => {
     <ComponentContent styles={props.params.styles} id={props.params.RenderingIdentifier}>
       <>
         {mode.isEditing ? (
-          <Text field={text} />
+          <Text field={titleField} />
         ) : (
           <Link field={link}>
-            <Text field={text} />
+            <Text field={titleField} />
           </Link>
         )}
       </>

--- a/examples/kit-nextjs-product-listing/src/components/sxa/Title.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/sxa/Title.tsx
@@ -60,9 +60,7 @@ export const Default = (props: TitleProps): JSX.Element => {
   const link: LinkField = {
     value: {
       href: datasource?.url?.path,
-      title:
-        (titleField?.value ? String(titleField.value) : undefined) ||
-        datasource?.field?.jsonValue?.value,
+      title: titleField?.value ? String(titleField.value) : datasource?.field?.jsonValue?.value,
     },
   };
   if (!mode.isNormal) {


### PR DESCRIPTION
## What
Ensure the Title field rendering uses the route's Title field so that it includes the correct Experience Editor metadata (`chrometype="field"`) and is editable.

## Why
Previously, the Title component rendered the field from `contextItem`, which did not provide the required metadata. As a result, the Title was not editable in the Experience Editor. Starter templates worked, but new components added to the page were not editable.

## How
- Updated `Title.tsx` to use `page.layout.sitecore.route?.fields?.pageTitle` instead of `contextItem`.
- Verified that the `<Text />` component now renders with EE metadata.