### PR TITLE
Fix insert options for Speakers page in SYNC site to only allow Audio Product pages

### DIFF
--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
@@ -7,8 +7,6 @@ SharedFields:
 - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
   Hint: __Masters
   Value: |
-    {AC9DE9BE-8E86-4147-8FBC-739D5560408B}
-    {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
     {1B76AF75-DD75-450C-92E3-FF0F339F490B}
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
@@ -4,101 +4,102 @@ Parent: "9660ff60-8e47-4efc-b22d-bac3fd04c8d7"
 Template: "ac9de9be-8e86-4147-8fbc-739d5560408b"
 Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Speakers/Speakers"
 SharedFields:
-- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
-  Hint: __Masters
-  Value: |
-    {1B76AF75-DD75-450C-92E3-FF0F339F490B}
-- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
-  Hint: __Thumbnail
-  Value: |
-    <image mediaid="{9C453FD3-7D15-4DA9-A2B7-C063601AD608}" />
-- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
-  Hint: __Shared revision
-  Value: "75602b55-2a90-4bca-bbcc-5e484f1ed485"
+  - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+    Hint: __Masters
+    Value: |
+      {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
+      {1B76AF75-DD75-450C-92E3-FF0F339F490B}
+  - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+    Hint: __Thumbnail
+    Value: |
+      <image mediaid="{9C453FD3-7D15-4DA9-A2B7-C063601AD608}" />
+  - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+    Hint: __Shared revision
+    Value: "75602b55-2a90-4bca-bbcc-5e484f1ed485"
 Languages:
-- Language: en
-  Versions:
-  - Version: 1
-    Fields:
-    - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
-      Hint: __Final Renderings
-      Value: |
-        <r xmlns:p="p" xmlns:s="s"
-          p:p="1">
-          <d
-            id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
-            <r
-              uid="{CBEBC269-71EF-475E-9F7D-C02498D0B172}"
-              p:before="*"
-              s:ds="local:/Data/Page Header ST"
-              s:id="{AF1983DD-7D75-40CB-B852-73C02ED1692F}"
-              s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames=%7BED62968F-D86F-492C-93B5-1E5578D386F4%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
-              s:ph="headless-main" />
-            <r
-              uid="{F3342772-42D8-4D33-9BAF-F977247C6137}"
-              p:after="r[@uid='{CBEBC269-71EF-475E-9F7D-C02498D0B172}']"
-              s:ds="local:/Data/ImageBanner 1"
-              s:id="{D627A749-9606-4B9B-AF4C-E4AFD0818854}"
-              s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=7"
-              s:ph="headless-main" />
-            <r
-              uid="{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}"
-              p:after="r[@uid='{F3342772-42D8-4D33-9BAF-F977247C6137}']"
-              s:ds="local:/Data/FeatureBanner 1"
-              s:id="{6850377F-83D9-4C25-B26D-4CE1BC80BA3D}"
-              s:par="FieldNames=%7B934A1850-7234-4014-B819-9F5B5F274E15%7D&amp;CSSStyles&amp;DynamicPlaceholderId=5"
-              s:ph="headless-main" />
-            <r
-              uid="{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}"
-              p:after="r[@uid='{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}']"
-              s:ds="local:/Data/MultiPromo 3"
-              s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
-              s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=2"
-              s:ph="headless-main" />
-            <r
-              uid="{C68BDF6F-DD88-48D3-B988-5D57097154F6}"
-              p:after="r[@uid='{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}']"
-              s:ds="local:/Data/ProductComparison 2"
-              s:id="{7FDC6DFC-A4DE-4352-9FA9-745B5CD457C6}"
-              s:par="showButton=1&amp;GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=6"
-              s:ph="headless-main" />
-            <r
-              uid="{DB9725BE-31D6-4386-ACE5-514D413311B1}"
-              p:after="r[@uid='{C68BDF6F-DD88-48D3-B988-5D57097154F6}']"
-              s:ds="local:/Data/MultiPromo 4"
-              s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
-              s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=3&amp;Styles=%7BC888E8A0-773E-4BD8-8EB4-A8B20DCD8D6E%7D"
-              s:ph="headless-main" />
-            <r
-              uid="{2FC6B25B-470D-47B4-AB25-631F8FDDF32D}"
-              p:after="*[1=2]"
-              s:ds="local:/Data/Accordion 1"
-              s:id="{913E30C7-63C2-4A2B-9D44-B2ADAEED6BC2}"
-              s:par="FieldNames=%7B0A38E986-2333-4DAD-9883-D62CA6E1BE3D%7D&amp;orientation&amp;CSSStyles&amp;DynamicPlaceholderId=4"
-              s:ph="headless-main" />
-          </d>
-        </r>
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250530T133844Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\neli.kostadinova@sitecore.com
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\neli.kostadinova@sitecore.com
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "1825a019-fe98-4eff-9eb0-ba91c3cfd61e"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\brandon.bruno@sitecore.com
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250630T170441Z
-    - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
-      Hint: ogTitle
-      Value: Speakers
+  - Language: en
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
+            Hint: __Final Renderings
+            Value: |
+              <r xmlns:p="p" xmlns:s="s"
+                p:p="1">
+                <d
+                  id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+                  <r
+                    uid="{CBEBC269-71EF-475E-9F7D-C02498D0B172}"
+                    p:before="*"
+                    s:ds="local:/Data/Page Header ST"
+                    s:id="{AF1983DD-7D75-40CB-B852-73C02ED1692F}"
+                    s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames=%7BED62968F-D86F-492C-93B5-1E5578D386F4%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{F3342772-42D8-4D33-9BAF-F977247C6137}"
+                    p:after="r[@uid='{CBEBC269-71EF-475E-9F7D-C02498D0B172}']"
+                    s:ds="local:/Data/ImageBanner 1"
+                    s:id="{D627A749-9606-4B9B-AF4C-E4AFD0818854}"
+                    s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=7"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}"
+                    p:after="r[@uid='{F3342772-42D8-4D33-9BAF-F977247C6137}']"
+                    s:ds="local:/Data/FeatureBanner 1"
+                    s:id="{6850377F-83D9-4C25-B26D-4CE1BC80BA3D}"
+                    s:par="FieldNames=%7B934A1850-7234-4014-B819-9F5B5F274E15%7D&amp;CSSStyles&amp;DynamicPlaceholderId=5"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}"
+                    p:after="r[@uid='{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}']"
+                    s:ds="local:/Data/MultiPromo 3"
+                    s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
+                    s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=2"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{C68BDF6F-DD88-48D3-B988-5D57097154F6}"
+                    p:after="r[@uid='{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}']"
+                    s:ds="local:/Data/ProductComparison 2"
+                    s:id="{7FDC6DFC-A4DE-4352-9FA9-745B5CD457C6}"
+                    s:par="showButton=1&amp;GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=6"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{DB9725BE-31D6-4386-ACE5-514D413311B1}"
+                    p:after="r[@uid='{C68BDF6F-DD88-48D3-B988-5D57097154F6}']"
+                    s:ds="local:/Data/MultiPromo 4"
+                    s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
+                    s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=3&amp;Styles=%7BC888E8A0-773E-4BD8-8EB4-A8B20DCD8D6E%7D"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{2FC6B25B-470D-47B4-AB25-631F8FDDF32D}"
+                    p:after="*[1=2]"
+                    s:ds="local:/Data/Accordion 1"
+                    s:id="{913E30C7-63C2-4A2B-9D44-B2ADAEED6BC2}"
+                    s:par="FieldNames=%7B0A38E986-2333-4DAD-9883-D62CA6E1BE3D%7D&amp;orientation&amp;CSSStyles&amp;DynamicPlaceholderId=4"
+                    s:ph="headless-main" />
+                </d>
+              </r>
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250530T133844Z
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\neli.kostadinova@sitecore.com
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\neli.kostadinova@sitecore.com
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "1825a019-fe98-4eff-9eb0-ba91c3cfd61e"
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\brandon.bruno@sitecore.com
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250630T170441Z
+          - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
+            Hint: ogTitle
+            Value: Speakers

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml
@@ -4,102 +4,102 @@ Parent: "9660ff60-8e47-4efc-b22d-bac3fd04c8d7"
 Template: "ac9de9be-8e86-4147-8fbc-739d5560408b"
 Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Speakers/Speakers"
 SharedFields:
-  - ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
-    Hint: __Masters
-    Value: |
-      {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
-      {1B76AF75-DD75-450C-92E3-FF0F339F490B}
-  - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
-    Hint: __Thumbnail
-    Value: |
-      <image mediaid="{9C453FD3-7D15-4DA9-A2B7-C063601AD608}" />
-  - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
-    Hint: __Shared revision
-    Value: "75602b55-2a90-4bca-bbcc-5e484f1ed485"
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Value: |
+    {C14B6289-8AC2-439C-9E5B-40DE9F820C3F}
+    {1B76AF75-DD75-450C-92E3-FF0F339F490B}
+- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+  Hint: __Thumbnail
+  Value: |
+    <image mediaid="{9C453FD3-7D15-4DA9-A2B7-C063601AD608}" />
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "75602b55-2a90-4bca-bbcc-5e484f1ed485"
 Languages:
-  - Language: en
-    Versions:
-      - Version: 1
-        Fields:
-          - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
-            Hint: __Final Renderings
-            Value: |
-              <r xmlns:p="p" xmlns:s="s"
-                p:p="1">
-                <d
-                  id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
-                  <r
-                    uid="{CBEBC269-71EF-475E-9F7D-C02498D0B172}"
-                    p:before="*"
-                    s:ds="local:/Data/Page Header ST"
-                    s:id="{AF1983DD-7D75-40CB-B852-73C02ED1692F}"
-                    s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames=%7BED62968F-D86F-492C-93B5-1E5578D386F4%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{F3342772-42D8-4D33-9BAF-F977247C6137}"
-                    p:after="r[@uid='{CBEBC269-71EF-475E-9F7D-C02498D0B172}']"
-                    s:ds="local:/Data/ImageBanner 1"
-                    s:id="{D627A749-9606-4B9B-AF4C-E4AFD0818854}"
-                    s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=7"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}"
-                    p:after="r[@uid='{F3342772-42D8-4D33-9BAF-F977247C6137}']"
-                    s:ds="local:/Data/FeatureBanner 1"
-                    s:id="{6850377F-83D9-4C25-B26D-4CE1BC80BA3D}"
-                    s:par="FieldNames=%7B934A1850-7234-4014-B819-9F5B5F274E15%7D&amp;CSSStyles&amp;DynamicPlaceholderId=5"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}"
-                    p:after="r[@uid='{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}']"
-                    s:ds="local:/Data/MultiPromo 3"
-                    s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
-                    s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=2"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{C68BDF6F-DD88-48D3-B988-5D57097154F6}"
-                    p:after="r[@uid='{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}']"
-                    s:ds="local:/Data/ProductComparison 2"
-                    s:id="{7FDC6DFC-A4DE-4352-9FA9-745B5CD457C6}"
-                    s:par="showButton=1&amp;GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=6"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{DB9725BE-31D6-4386-ACE5-514D413311B1}"
-                    p:after="r[@uid='{C68BDF6F-DD88-48D3-B988-5D57097154F6}']"
-                    s:ds="local:/Data/MultiPromo 4"
-                    s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
-                    s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=3&amp;Styles=%7BC888E8A0-773E-4BD8-8EB4-A8B20DCD8D6E%7D"
-                    s:ph="headless-main" />
-                  <r
-                    uid="{2FC6B25B-470D-47B4-AB25-631F8FDDF32D}"
-                    p:after="*[1=2]"
-                    s:ds="local:/Data/Accordion 1"
-                    s:id="{913E30C7-63C2-4A2B-9D44-B2ADAEED6BC2}"
-                    s:par="FieldNames=%7B0A38E986-2333-4DAD-9883-D62CA6E1BE3D%7D&amp;orientation&amp;CSSStyles&amp;DynamicPlaceholderId=4"
-                    s:ph="headless-main" />
-                </d>
-              </r>
-          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-            Hint: __Created
-            Value: 20250530T133844Z
-          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-            Hint: __Owner
-            Value: |
-              sitecore\neli.kostadinova@sitecore.com
-          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-            Hint: __Created by
-            Value: |
-              sitecore\neli.kostadinova@sitecore.com
-          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-            Hint: __Revision
-            Value: "1825a019-fe98-4eff-9eb0-ba91c3cfd61e"
-          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-            Hint: __Updated by
-            Value: |
-              sitecore\brandon.bruno@sitecore.com
-          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-            Hint: __Updated
-            Value: 20250630T170441Z
-          - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
-            Hint: ogTitle
-            Value: Speakers
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
+      Hint: __Final Renderings
+      Value: |
+        <r xmlns:p="p" xmlns:s="s"
+          p:p="1">
+          <d
+            id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+            <r
+              uid="{CBEBC269-71EF-475E-9F7D-C02498D0B172}"
+              p:before="*"
+              s:ds="local:/Data/Page Header ST"
+              s:id="{AF1983DD-7D75-40CB-B852-73C02ED1692F}"
+              s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames=%7BED62968F-D86F-492C-93B5-1E5578D386F4%7D&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=1"
+              s:ph="headless-main" />
+            <r
+              uid="{F3342772-42D8-4D33-9BAF-F977247C6137}"
+              p:after="r[@uid='{CBEBC269-71EF-475E-9F7D-C02498D0B172}']"
+              s:ds="local:/Data/ImageBanner 1"
+              s:id="{D627A749-9606-4B9B-AF4C-E4AFD0818854}"
+              s:par="GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=7"
+              s:ph="headless-main" />
+            <r
+              uid="{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}"
+              p:after="r[@uid='{F3342772-42D8-4D33-9BAF-F977247C6137}']"
+              s:ds="local:/Data/FeatureBanner 1"
+              s:id="{6850377F-83D9-4C25-B26D-4CE1BC80BA3D}"
+              s:par="FieldNames=%7B934A1850-7234-4014-B819-9F5B5F274E15%7D&amp;CSSStyles&amp;DynamicPlaceholderId=5"
+              s:ph="headless-main" />
+            <r
+              uid="{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}"
+              p:after="r[@uid='{16BF1997-699E-4E1E-AD6C-560AE2BFE6E4}']"
+              s:ds="local:/Data/MultiPromo 3"
+              s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
+              s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=2"
+              s:ph="headless-main" />
+            <r
+              uid="{C68BDF6F-DD88-48D3-B988-5D57097154F6}"
+              p:after="r[@uid='{4B315461-8CF8-4C9E-AD4E-6D759BAF132E}']"
+              s:ds="local:/Data/ProductComparison 2"
+              s:id="{7FDC6DFC-A4DE-4352-9FA9-745B5CD457C6}"
+              s:par="showButton=1&amp;GridParameters=%7BF61E01E9-711A-4C99-AE30-4E28463E1DF7%7D&amp;FieldNames&amp;Styles&amp;RenderingIdentifier&amp;CSSStyles&amp;DynamicPlaceholderId=6"
+              s:ph="headless-main" />
+            <r
+              uid="{DB9725BE-31D6-4386-ACE5-514D413311B1}"
+              p:after="r[@uid='{C68BDF6F-DD88-48D3-B988-5D57097154F6}']"
+              s:ds="local:/Data/MultiPromo 4"
+              s:id="{D806DDF7-39A7-4A6D-8E0A-D138BC53845D}"
+              s:par="FieldNames=%7BD4BEAB29-982A-4D95-B38F-79BBBE3D6731%7D&amp;numColumns&amp;CSSStyles&amp;DynamicPlaceholderId=3&amp;Styles=%7BC888E8A0-773E-4BD8-8EB4-A8B20DCD8D6E%7D"
+              s:ph="headless-main" />
+            <r
+              uid="{2FC6B25B-470D-47B4-AB25-631F8FDDF32D}"
+              p:after="*[1=2]"
+              s:ds="local:/Data/Accordion 1"
+              s:id="{913E30C7-63C2-4A2B-9D44-B2ADAEED6BC2}"
+              s:par="FieldNames=%7B0A38E986-2333-4DAD-9883-D62CA6E1BE3D%7D&amp;orientation&amp;CSSStyles&amp;DynamicPlaceholderId=4"
+              s:ph="headless-main" />
+          </d>
+        </r>
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20250530T133844Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\neli.kostadinova@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\neli.kostadinova@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "1825a019-fe98-4eff-9eb0-ba91c3cfd61e"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\brandon.bruno@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20250630T170441Z
+    - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
+      Hint: ogTitle
+      Value: Speakers


### PR DESCRIPTION
**Solution**
Modified `__Masters` field in Speakers template to only inherit from Audio Product Page template (`{1B76AF75-DD75-450C-92E3-FF0F339F490B}`).

**Changes**
File: `authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers.yml`
Removed: Generic Page template inheritance
Kept: Audio Product Page template only