### PR TITLE
Issue: C# code Publishing outside Repo folder

### DIFF
--- a/authoring/platform/Properties/PublishProfiles/Local.pubxml
+++ b/authoring/platform/Properties/PublishProfiles/Local.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <PublishProvider>FileSystem</PublishProvider>
-    <PublishUrl>..\..\..\local-containers\docker\deploy\platform</PublishUrl>
+    <PublishUrl>..\..\local-containers\docker\deploy\platform</PublishUrl>
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <SiteUrlToLaunchAfterPublish />
   </PropertyGroup>


### PR DESCRIPTION
Issue: C# code Publishing outside Repo folder. 

MS Visual Studio should publish on Repo folder like d:\demo\Oct2025\xmcloud-starter-js\local-containers\docker\deploy\platform. However as of now its deploying in d:\demo\Oct2025\local-containers\docker\deploy\platform