### PR TITLE
Add missing content to Terra product page of Alaris site

### DIFF
--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra.yml
@@ -4,83 +4,125 @@ Parent: "7070586a-d5a2-4997-82a0-0286cc88b58f"
 Template: "9a52202d-3a77-4f6d-b9bd-6aeced9bd49a"
 Path: "/sitecore/templates/Branches/Project/click-click-launch/Alaris/Add Products/Products/Terra"
 SharedFields:
-- ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
-  Hint: __Thumbnail
-  Value: |
-    <image mediaid="{C1270805-FEFA-43E0-884B-BE35A51DCDE9}" />
+  - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
+    Hint: __Thumbnail
+    Value: |
+      <image mediaid="{C1270805-FEFA-43E0-884B-BE35A51DCDE9}" />
 Languages:
-- Language: en
-  Versions:
-  - Version: 1
+  - Language: en
     Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250321T182818Z
-    - ID: "27cd428b-f652-4534-b76f-33f64b742659"
-      Hint: pageShortTitle
-      Value: Terra
-    - ID: "5272817a-75b7-4554-a5ef-2cc4930034d2"
-      Hint: pageSubtitle
-      Value: 
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5c01b675-9b56-4d6b-aee4-0ecb1a0021f6"
-      Hint: pageTitle
-      Value: Terra
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "65408499-25bc-49d0-a2ff-b2fdd798aafc"
-      Hint: ogImage
-      Value: |
-        <image mediaid="11356a96-9e1e-457e-8856-24bfae1ea602" />
-    - ID: "69c33f09-f870-4d18-86c6-c34d9f3ac290"
-      Hint: taxContentType
-      Value: "{EAE5FAD7-EC15-468A-8372-29148C78057C}"
-    - ID: "8535365d-ae76-4875-ab5b-a618d5819af0"
-      Hint: metadataTitle
-      Value: Alaris Terra
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "85aa4033-30b0-4e66-b115-a16e297bf6af"
-    - ID: "a43f5863-a6f4-49d2-904b-5b88ce4b2a4c"
-      Hint: productFeatureText
-      Value: |
-        Adaptive AI that learns and responds 
-        intuitively to every journey.
-    - ID: "b7979eed-6bcb-4117-80bc-4bcc6aab12a9"
-      Hint: pageHeaderTitle
-      Value: Terra
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d63dce88-2d39-4c77-aaca-2e1f8492175c"
-      Hint: productFeatureTitle
-      Value: TrailSense AI
-    - ID: "d861f60f-a947-4ead-a9b4-80d217ab445c"
-      Hint: productThumbnail
-      Value: |
-        <image mediaid="11356a96-9e1e-457e-8856-24bfae1ea602" alt="Terra" />
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250321T183112Z
-    - ID: "e8521086-d2b8-4581-bd01-3d89420f8cf7"
-      Hint: productName
-      Value: Alaris Terra
-    - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
-      Hint: ogTitle
-      Value: Alaris Terra
-    - ID: "edd12642-fcff-41dc-b3f7-c5f2a6008319"
-      Hint: productBasePrice
-      Value: From $92,500
-    - ID: "efbce7e8-6d4e-49e2-9b48-a9ab9a1e6fd7"
-      Hint: pageThumbnail
-      Value: |
-        <image mediaid="11356a96-9e1e-457e-8856-24bfae1ea602" alt="Alaris Terra" />
-    - ID: "fa388749-2de0-427d-b421-ad2a5639de10"
-      Hint: productDrivingRange
-      Value: 384mi
+      - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+        Hint: __Display name
+        Value: Terra
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "04bf00db-f5fb-41f7-8ab7-22408372a981"
+            Hint: __Final Renderings
+            Value: |
+              <r xmlns:p="p" xmlns:s="s"
+                p:p="1">
+                <d
+                  id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+                  <r
+                    uid="{E9152102-E995-45CC-AECC-8909E68D90A7}"
+                    p:before="*"
+                    s:id="{E80C2A78-FCC2-4D32-8EC5-4133F608BE5C}"
+                    s:par="colorScheme&amp;excludeTopMargin&amp;inset&amp;CSSStyles&amp;DynamicPlaceholderId=1"
+                    s:ph="headless-main" />
+                  <r
+                    uid="{81E4D0C2-D178-48A8-A77A-ECF53033DD2B}"
+                    p:after="r[@uid='{E9152102-E995-45CC-AECC-8909E68D90A7}']"
+                    s:ds="local:/Data/Page Header 1"
+                    s:id="{C78595D2-0892-4EC6-9FF8-B71EDBF17861}"
+                    s:par="FieldNames=%7B504C8462-ED9C-4031-A545-C92D5D67E9BA%7D&amp;CSSStyles&amp;DynamicPlaceholderId=2"
+                    s:ph="/headless-main/container-fullbleed-1" />
+                  <r
+                    uid="{08CC2408-D09B-48DC-8ADC-AED77D561DED}"
+                    p:after="r[@uid='{81E4D0C2-D178-48A8-A77A-ECF53033DD2B}']"
+                    s:ds="local:/Data/Terra Text Banner"
+                    s:id="{E7B031D3-161F-4391-8B23-785FC8445D1E}"
+                    s:par="FieldNames=%7BB6249B9B-86AB-40B3-8B0E-0A4ED7ADAD9E%7D&amp;CSSStyles&amp;DynamicPlaceholderId=3"
+                    s:ph="/headless-main/container-fullbleed-1" />
+                  <r
+                    uid="{E8ED4E7F-0264-48BC-A4F0-A80D97BB4800}"
+                    p:after="r[@uid='{08CC2408-D09B-48DC-8ADC-AED77D561DED}']"
+                    s:id="{02340885-3692-4CAD-AC11-ED61206501A3}"
+                    s:par="excludeTopMargin&amp;CSSStyles&amp;DynamicPlaceholderId=4"
+                    s:ph="/headless-main/container-fullbleed-1" />
+                  <r
+                    uid="{93405308-9550-44F9-8766-080B0FF89B02}"
+                    p:after="*[1=2]"
+                    s:ds="local:/Data/Image Gallery 1"
+                    s:id="{939246CC-DAAB-4FE9-A265-536995A04122}"
+                    s:par="FieldNames=%7B85BCDAF1-E2F4-4BC5-B6EE-BA31EF6E39B0%7D&amp;CSSStyles&amp;DynamicPlaceholderId=5"
+                    s:ph="/headless-main/container-fullbleed-1/container-fullwidth-4" />
+                </d>
+              </r>
+          - ID: "2485de13-6c39-468c-9c26-fe08c27088f4"
+            Hint: pageSummary
+            Value: Alaris Terra
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250321T182818Z
+          - ID: "27cd428b-f652-4534-b76f-33f64b742659"
+            Hint: pageShortTitle
+            Value: Terra
+          - ID: "5272817a-75b7-4554-a5ef-2cc4930034d2"
+            Hint: pageSubtitle
+            Value: "Starting at $92,500 – Conquer any terrain with Alaris Terra's advanced TrailSense AI and unmatched off-road capability."
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\Admin
+          - ID: "5c01b675-9b56-4d6b-aee4-0ecb1a0021f6"
+            Hint: pageTitle
+            Value: Terra
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\Admin
+          - ID: "69c33f09-f870-4d18-86c6-c34d9f3ac290"
+            Hint: taxContentType
+            Value: "{EAE5FAD7-EC15-468A-8372-29148C78057C}"
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "85aa4033-30b0-4e66-b115-a16e297bf6af"
+          - ID: "a43f5863-a6f4-49d2-904b-5b88ce4b2a4c"
+            Hint: productFeatureText
+            Value: |
+              Adaptive AI that learns and responds 
+              intuitively to every journey.
+          - ID: "b7979eed-6bcb-4117-80bc-4bcc6aab12a9"
+            Hint: pageHeaderTitle
+            Value: 2025 Alaris Terra
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\Admin
+          - ID: "d63dce88-2d39-4c77-aaca-2e1f8492175c"
+            Hint: productFeatureTitle
+            Value: TrailSense AI
+          - ID: "d861f60f-a947-4ead-a9b4-80d217ab445c"
+            Hint: productThumbnail
+            Value: |
+              <image mediaid="11356a96-9e1e-457e-8856-24bfae1ea602" alt="Terra" />
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250321T183112Z
+          - ID: "e8521086-d2b8-4581-bd01-3d89420f8cf7"
+            Hint: productName
+            Value: Alaris Terra
+          - ID: "ed981ca0-271d-4543-b735-ecc955bd58a1"
+            Hint: ogTitle
+            Value: Alaris Terra
+          - ID: "edd12642-fcff-41dc-b3f7-c5f2a6008319"
+            Hint: productBasePrice
+            Value: From $92,500
+          - ID: "efbce7e8-6d4e-49e2-9b48-a9ab9a1e6fd7"
+            Hint: pageThumbnail
+            Value: |
+              <image mediaid="11356a96-9e1e-457e-8856-24bfae1ea602" alt="Alaris Terra" />
+          - ID: "fa388749-2de0-427d-b421-ad2a5639de10"
+            Hint: productDrivingRange
+            Value: 384mi

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data.yml
@@ -1,0 +1,31 @@
+---
+ID: "875e30d2-2da2-4940-9619-bd334844ae18"
+Parent: "9dd619fc-5273-4734-ae98-bdefc4dce1ae"
+Template: "1c82e550-ebcd-4e5d-8abd-d50d0809541e"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/Alaris/Add Products/Products/Terra/Data"
+Languages:
+  - Language: en
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250321T182818Z
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\Admin
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\Admin
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "bd09842a-5fb4-4b4a-9238-e69720c1b7c6"
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\Admin
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250321T182818Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Image Gallery 1.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Image Gallery 1.yml
@@ -1,0 +1,53 @@
+---
+ID: "427ed81c-0abe-48af-8bdd-c6670d4ff997"
+Parent: "875e30d2-2da2-4940-9619-bd334844ae18"
+Template: "4eb24890-61ec-4283-8c61-c55a86d1fe2a"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/Alaris/Add Products/Products/Terra/Data/Image Gallery 1"
+Languages:
+  - Language: en
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250321T182818Z
+          - ID: "45324e3c-4e19-41d7-9497-bdcde2228eb1"
+            Hint: image2
+            Value: |
+              <image mediaid="F76AB4B8-9973-42F5-B8F0-9925A3963877" />
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\Admin
+          - ID: "58d5ed64-d50a-4ea7-ba39-f5d2e98c7c3e"
+            Hint: title
+            Value: "Adventure Redefined"
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\Admin
+          - ID: "69a878be-bdf4-4509-a304-238b0a24bac4"
+            Hint: image4
+            Value: |
+              <image mediaid="65385841-6ae3-489c-a1cd-1ab9236bdc57" />
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "9bf70719-d507-4f17-b765-b6381a23a2ed"
+          - ID: "a5a74a19-c942-421c-9ff5-c3116fcffa0d"
+            Hint: image1
+            Value: |
+              <image mediaid="DB422FCB-809B-43BD-B8BF-D3EA332FEB98" />
+          - ID: "a7be6790-3f1a-43fc-94bb-302604c97081"
+            Hint: description
+            Value: "Experience the ultimate off-road adventure with Terra's intelligent TrailSense AI and rugged capability designed for every terrain."
+          - ID: "b293c09d-fd8e-4eee-97bd-0f30f3f4ca10"
+            Hint: image3
+            Value: |
+              <image mediaid="7d2baee6-8c25-4cce-bfe8-149e95de021d" />
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\Admin
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250321T182818Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Page Header 1.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Page Header 1.yml
@@ -1,0 +1,43 @@
+---
+ID: "c2c8c7a3-3ffb-4c74-979d-8caf128f5c73"
+Parent: "875e30d2-2da2-4940-9619-bd334844ae18"
+Template: "754d4fd3-aa54-46d0-84bd-0bb43f8aeba0"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/Alaris/Add Products/Products/Terra/Data/Page Header 1"
+Languages:
+  - Language: en
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "050b0870-ebcd-41bc-846e-0a5e4828c3a7"
+            Hint: link1
+            Value: |
+              <link linktype="internal" id="7d507f7b-015f-439b-9f08-f7ec4f81b1e8" anchor="" querystring="" target="" class="" text="Schedule a Test Drive" title=""/>
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250321T182818Z
+          - ID: "31ada09a-aeeb-4807-9ad2-eccd3ad7e40a"
+            Hint: imageRequired
+            Value: |
+              <image mediaid="2900381c-4a6d-4a48-bfae-cd454b97cd64" />
+          - ID: "4a3ab7ba-d36c-4133-96a3-30e15566056f"
+            Hint: link2
+            Value: |
+              <link linktype="internal" id="a27287ed-a7c0-47f4-ad13-768a665a419c" anchor="" querystring="" target="" class="" text="Reserve" title=""/>
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\Admin
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\Admin
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "1b086bd5-71ba-4f08-a5ad-449b2ec092c1"
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\Admin
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250321T182818Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Terra Text Banner.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/Alaris/Add Products/Products/Terra/Data/Terra Text Banner.yml
@@ -1,0 +1,37 @@
+---
+ID: "1524bc13-7cbc-44ed-88ba-c2ab509e8516"
+Parent: "875e30d2-2da2-4940-9619-bd334844ae18"
+Template: "1313c346-ca98-4657-bb96-d89e35b2235f"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/Alaris/Add Products/Products/Terra/Data/Terra Text Banner"
+Languages:
+  - Language: en
+    Versions:
+      - Version: 1
+        Fields:
+          - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+            Hint: __Created
+            Value: 20250321T182818Z
+          - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+            Hint: __Owner
+            Value: |
+              sitecore\Admin
+          - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+            Hint: __Created by
+            Value: |
+              sitecore\Admin
+          - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+            Hint: __Revision
+            Value: "9062cc67-e268-4a40-ae20-2470d9f7ad0b"
+          - ID: "b52480d8-082e-45b3-8c7c-1995592ca5f6"
+            Hint: heading
+            Value: "Conquer Every Trail with Confidence"
+          - ID: "b60aa9f3-869e-4312-a810-c9f2f86a759b"
+            Hint: description
+            Value: "The Alaris Terra combines rugged off-road capability with intelligent TrailSense AI technology. Whether navigating mountain passes or urban streets, Terra adapts to every terrain with precision and power, delivering an unmatched adventure experience."
+          - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+            Hint: __Updated by
+            Value: |
+              sitecore\Admin
+          - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+            Hint: __Updated
+            Value: 20250321T182818Z


### PR DESCRIPTION
## Problem
The Terra product page existed but had no content configured. The page was essentially empty with no components, images, or product information.

## Root Cause
The Terra page template was created but content components were never added to YML file to populate the page.

## Solution
Added complete content structure and components to the Terra product page following the same pattern as other Alaris product pages (Aero, Nexa).

## Changes Made

- Added Component Layout Configuration (`Terra.yml`)
- Added Page Header 1 component reference to (`Page Header 1.yml`)
- Added Terra Text Banner component reference to (`Terra Text Banner.yml`)
- Added Image Gallery 1 component reference to (`Image Gallery 1.yml`)