### PR TITLE
Fix Alaris Animated Promo field Image contains broken links

### DIFF
--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Promos/AnimatedPromo/__Standard Values.yml
@@ -39,7 +39,7 @@ Languages:
     - ID: "84a2a397-786e-43bd-85a0-bfbcc51fc3f3"
       Hint: image
       Value: |
-        <image mediaid="{46B04574-E3CB-40A3-83D8-A546B0CCE3FA}" alt="Bumper" />
+        <image mediaid="{865E1E26-2CF0-4ADC-86CF-0FC3D0A76658}" alt="Electric Car" />
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
       Value: "9dcb454c-83dd-423d-907d-5a0e93b08eda"


### PR DESCRIPTION
Update alaris Animated promo default image media ID and alt text