### PR TITLE
Refactor xmcloud.build.json to reorder rendering hosts for consistency

### DIFF
--- a/xmcloud.build.json
+++ b/xmcloud.build.json
@@ -1,23 +1,5 @@
 {
   "renderingHosts": {
-    "basic-nextjs": {
-      "path": "./examples/kit-nextjs-skate-park",
-      "nodeVersion": "22.11.0",
-      "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
-      "enabled": true,
-      "type": "sxa",
-      "buildCommand": "build",
-      "runCommand": "next:start"
-    },
-    "basic-nextjs-pages-router": {
-      "path": "./examples/basic-nextjs-pages-router",
-      "nodeVersion": "22.11.0",
-      "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
-      "enabled": false,
-      "type": "sxa",
-      "buildCommand": "build",
-      "runCommand": "next:start"
-    },
     "kit-nextjs-skate-park": {
       "path": "./examples/kit-nextjs-skate-park",
       "nodeVersion": "22.11.0",
@@ -59,6 +41,24 @@
       "nodeVersion": "22.11.0",
       "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
       "enabled": true,
+      "type": "sxa",
+      "buildCommand": "build",
+      "runCommand": "next:start"
+    },
+    "basic-nextjs": {
+      "path": "./examples/basic-nextjs",
+      "nodeVersion": "22.11.0",
+      "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
+      "enabled": true,
+      "type": "sxa",
+      "buildCommand": "build",
+      "runCommand": "next:start"
+    },
+    "basic-nextjs-pages-router": {
+      "path": "./examples/basic-nextjs-pages-router",
+      "nodeVersion": "22.11.0",
+      "jssDeploymentSecret": "110F1C44A496B45478640DD36F80C18C9",
+      "enabled": false,
       "type": "sxa",
       "buildCommand": "build",
       "runCommand": "next:start"


### PR DESCRIPTION
<!--- ⚠️ IMPORTANT: This PR should target the `dmz` branch -->
<!--- Please ensure the base branch is set to `dmz` before creating this PR -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Skate Park site (currently named Basic in XM Cloud) always picks the first rendering host in the xmcloud.build.json file. In the current solution, when a user tries to create a Skate Park site, XM Cloud creates it using the Basic example project, which is an empty project. To maintain consistency, I moved the first two rendering hosts related to the Basic site to the bottom.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
