### PR TITLE
Add package-lock.json to .gitignore files in all examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 *.itempackage
 *.sicpackage
 
+# Lock files - should not be committed
+package-lock.json
+
 #Ignore thumbnails created by Windows
 Thumbs.db
 #Ignore files built by Visual Studio

--- a/examples/basic-nextjs-pages-router/.gitignore
+++ b/examples/basic-nextjs-pages-router/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # next.js
 /.next*/
 /out/

--- a/examples/basic-nextjs/.gitignore
+++ b/examples/basic-nextjs/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # next.js
 /.next*/
 /out/

--- a/examples/basic-spa/.gitignore
+++ b/examples/basic-spa/.gitignore
@@ -2,4 +2,7 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 /.pnpm-store

--- a/examples/basic-spa/angular/.gitignore
+++ b/examples/basic-spa/angular/.gitignore
@@ -14,6 +14,9 @@ scjssconfig.json
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # local env files
 .env.local
 .env.*.local

--- a/examples/basic-spa/proxy/.gitignore
+++ b/examples/basic-spa/proxy/.gitignore
@@ -6,6 +6,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # local env files
 .env.local
 .env.*.local

--- a/examples/kit-nextjs-article-starter/.gitignore
+++ b/examples/kit-nextjs-article-starter/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # testing
 /coverage
 

--- a/examples/kit-nextjs-location-finder/.gitignore
+++ b/examples/kit-nextjs-location-finder/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # next.js
 /.next*/
 /out/

--- a/examples/kit-nextjs-product-listing/.gitignore
+++ b/examples/kit-nextjs-product-listing/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # next.js
 /.next*/
 /out/

--- a/examples/kit-nextjs-skate-park/.gitignore
+++ b/examples/kit-nextjs-skate-park/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 
+# Lock files
+package-lock.json
+
 # next.js
 /.next*/
 /out/


### PR DESCRIPTION
<!--- ⚠️ IMPORTANT: This PR should target the `dmz` branch -->
<!--- Please ensure the base branch is set to `dmz` before creating this PR -->

## Description / Motivation
Updated .gitignore files across the repository to ignore package-lock.json files:

- Added package-lock.json to the root .gitignore
- Added package-lock.json to all project-level .gitignore files in:
- examples/basic-nextjs/.gitignore
- examples/basic-nextjs-pages-router/.gitignore
- examples/kit-nextjs-article-starter/.gitignore
- examples/kit-nextjs-location-finder/.gitignore
- examples/kit-nextjs-product-listing/.gitignore
- examples/kit-nextjs-skate-park/.gitignore
- examples/basic-spa/.gitignore
- examples/basic-spa/angular/.gitignore
- examples/basic-spa/proxy/.gitignore

Prevents accidental commits of package-lock.json files
Reduces merge conflicts from lock file updates
Aligns with the project's approach of not committing generated lock files
Ensures consistent ignore rules across all starter projects



## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
