### PR TITLE
Update Traefik to v3.6.4 for Docker Desktop compatibility

### DIFF
--- a/local-containers/.env
+++ b/local-containers/.env
@@ -21,7 +21,7 @@ SQL_DATABASE_PREFIX=Sitecore
 
 # Other supporting images, including Sitecore modules and Docker tools
 TOOLS_IMAGE=scr.sitecore.com/tools/sitecore-xmcloud-docker-tools-assets
-TRAEFIK_IMAGE=traefik:v3.0.4-windowsservercore-ltsc2022
+TRAEFIK_IMAGE=traefik:v3.6.4-windowsservercore-ltsc2022
 
 # Windows and Node.js version for JSS
 NODEJS_PARENT_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/local-containers/docker-compose.override.yml
+++ b/local-containers/docker-compose.override.yml
@@ -34,6 +34,7 @@ services:
       - "traefik.http.routers.rendering-secure-nextjs.entrypoints=websecure"
       - "traefik.http.routers.rendering-secure-nextjs.rule=Host(`${RENDERING_HOST_NEXTJS}`)"
       - "traefik.http.routers.rendering-secure-nextjs.tls=true"
+      - "traefik.http.services.rendering-nextjs.loadbalancer.server.port=3000"
 
   # Mount the Traefik configuration and certs.
   traefik:

--- a/local-containers/docker-compose.yml
+++ b/local-containers/docker-compose.yml
@@ -123,3 +123,4 @@ services:
       - "traefik.http.routers.cm-secure.rule=Host(`${CM_HOST}`)"
       - "traefik.http.routers.cm-secure.tls=true"
       - "traefik.http.routers.cm-secure.middlewares=force-STS-Header"
+      - "traefik.http.services.cm.loadbalancer.server.port=80"


### PR DESCRIPTION
<!--- ⚠️ IMPORTANT: This PR should target the `dmz` branch -->
<!--- Please ensure the base branch is set to `dmz` before creating this PR -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
What changed:
Updated Traefik reverse proxy from version 3.0.4 to 3.6.4 in the local containers configuration.
Why:
Traefik 3.0.4 has known compatibility issues with recent Docker Desktop versions, causing the local development environment to fail or behave unexpectedly. Upgrading to v3.6.4 resolves these compatibility issues and ensures smooth operation with the latest Docker Desktop releases.
Impact:
- Local development containers will now work correctly with Docker Desktop 4.x+ versions
- No breaking changes to existing configuration or workflows
- Developers will need to pull the new Traefik image on next docker compose up

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Manual Test/Other (Please elaborate)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Terms
<!-- Place an `x` in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
