### PR TITLE
Prevent search component from overlapping with header in preview mode

### DIFF
--- a/authoring/items/items/templates/items/ccl.modules/click-click-launch/SYNC Setup/Data Folders/Add Search Experiences Data Folder.yml
+++ b/authoring/items/items/templates/items/ccl.modules/click-click-launch/SYNC Setup/Data Folders/Add Search Experiences Data Folder.yml
@@ -1,0 +1,44 @@
+﻿---
+ID: "b668b4fa-5971-40c6-891c-1754c49ccf36"
+Parent: "3a40841b-5041-4682-b7a3-168a4bdd1c6d"
+Template: "3aea335c-d06d-45b1-841a-cbc8d2d1ce40"
+Path: "/sitecore/system/Settings/Project/click-click-launch/SYNC Setup/Data Folders/Add Search Experiences Data Folder"
+SharedFields:
+- ID: "52c91c75-6698-4701-a8a2-242ace59a8d6"
+  Hint: Location
+  Value: "{BA2F959D-A614-4C92-8B57-F1FC1A323ABE}"
+- ID: "7868e6bc-525c-4fce-ab8a-77da3e09b171"
+  Hint: Name
+  Value: Search Experiences
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "3fc699c3-1db7-4e78-957d-dcc930c82169"
+- ID: "e62c28f0-9d3b-46e2-8bec-a5e120542499"
+  Hint: Template
+  Value: "{DDEC7923-74B5-4C0C-86A6-04F551123581}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251218T094504Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "8f4e3945-21dc-489e-b9c8-1a7308b9b12c"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251218T094617Z

--- a/authoring/items/items/templates/items/ccl.modules/click-click-launch/SYNC Setup/Rendering Variants/Search Experience Variants.yml
+++ b/authoring/items/items/templates/items/ccl.modules/click-click-launch/SYNC Setup/Rendering Variants/Search Experience Variants.yml
@@ -1,0 +1,44 @@
+---
+ID: "76ee23d7-ce0f-407c-98b8-8e3ebc0a67e5"
+Parent: "072a9495-3c0b-42c6-b3e2-8637ff831261"
+Template: "3aea335c-d06d-45b1-841a-cbc8d2d1ce40"
+Path: "/sitecore/system/Settings/Project/click-click-launch/SYNC Setup/Rendering Variants/Search Experience Variants"
+SharedFields:
+- ID: "52c91c75-6698-4701-a8a2-242ace59a8d6"
+  Hint: Location
+  Value: "{C6F65339-F4DA-40FA-88D1-E1ECFFD54B91}"
+- ID: "7868e6bc-525c-4fce-ab8a-77da3e09b171"
+  Hint: Name
+  Value: Search Experience
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "ad36546c-d0a8-42c2-b745-7e387e619273"
+- ID: "e62c28f0-9d3b-46e2-8bec-a5e120542499"
+  Hint: Template
+  Value: "{9A579D3C-80AD-4105-B6DA-127E5F9256F0}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T072818Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "d76b286c-5530-455b-a249-f8a99e5c98af"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T073920Z

--- a/authoring/items/items/templates/items/ccl.renderings/click-click-launch/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.renderings/click-click-launch/Search Experience.yml
@@ -1,0 +1,31 @@
+---
+ID: "063d3bd9-fb6f-48b6-b1f0-0c4b1fbc9cdd"
+Parent: "9dbe8119-926f-400a-a738-6f3a43f86f75"
+Template: "7ee0975b-0698-493e-b3a2-0b2ef33d0522"
+Path: "/sitecore/layout/Renderings/Project/click-click-launch/Search Experience"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062702Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "406680f6-c5ef-451c-92ec-4dd89cde955e"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062702Z

--- a/authoring/items/items/templates/items/ccl.renderings/click-click-launch/Search Experience/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.renderings/click-click-launch/Search Experience/Search Experience.yml
@@ -1,0 +1,54 @@
+---
+ID: "f6952169-d48b-4612-9c31-ac13cac54c61"
+Parent: "063d3bd9-fb6f-48b6-b1f0-0c4b1fbc9cdd"
+Template: "04646a89-996f-4ee7-878a-ffdbf1f0ef0d"
+Path: "/sitecore/layout/Renderings/Project/click-click-launch/Search Experience/Search Experience"
+SharedFields:
+- ID: "037fe404-dd19-4bf7-8e30-4dadf68b27b0"
+  Hint: componentName
+  Value: SearchExperience
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Office/32x32/window_dialog.png
+- ID: "1a7c85e5-dc0b-490d-9187-bb1dbcb4c72f"
+  Hint: Datasource Template
+  Value: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience"
+- ID: "a77e8568-1ab3-44f1-a664-b7c37ec7810d"
+  Hint: Parameters Template
+  Value: "{BAD0EF57-D3BF-4841-A7DB-D6247F95F94A}"
+- ID: "b5b27af1-25ef-405c-87ce-369b3a004016"
+  Hint: Datasource Location
+  Value: "query:$site/*[@@name='Data']/*[@@templatename='Search Experience Folder']|query:$sharedSites/*[@@name='Data']/*[@@templatename='Search Experience Folder']"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7400c2c3-cb1b-471d-8e02-ac357ecde489"
+Languages:
+- Language: en
+  Fields:
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "f617190d-0e2a-40fc-b6ce-0303d04b4b67"
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062816Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "f8680bdc-0de3-47bd-8525-3bf00473ab37"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T063006Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Available Renderings/#name.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Available Renderings/#name.yml
@@ -37,9 +37,10 @@ SharedFields:
     {7943A20A-669D-4921-81EE-F4EC7F2E78A3}
     {F767C9BA-4DE5-4455-B921-EC158E0762EF}
     {90A922AA-E2A7-4553-A7AD-B89AC9318D6B}
+    {F6952169-D48B-4612-9C31-AC13CAC54C61}
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "24d1d1cb-3b82-472b-b7eb-85bf8525430a"
+  Value: "5fe9ddfd-c277-4704-be3a-920b87b36b13"
 Languages:
 - Language: en
   Versions:
@@ -54,11 +55,11 @@ Languages:
         sitecore\admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "98dab066-1dbb-42cb-8f3a-24c8e672e224"
+      Value: "8bad994b-e1f0-4143-be5e-71c2919fdc09"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\richard.seal@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250815T184208Z
+      Value: 20251217T073835Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience.yml
@@ -1,35 +1,31 @@
 ﻿---
-ID: "cdbd0b40-5095-4522-8ba9-d6db6edaa66b"
-Parent: "1b76af75-dd75-450c-92e3-ff0f339f490b"
-Template: "e269fbb5-3750-427a-9149-7aa950b49301"
-Path: "/sitecore/templates/Project/click-click-launch/Site/Audio Product Page/Product Details"
-SharedFields:
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 50
+ID: "12136754-a7f7-467c-80ad-243562e60925"
+Parent: "652f3679-867d-49d3-b380-17d80906ecc9"
+Template: "267d9ac7-5d85-4e9d-af89-99ab296cc218"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience"
 Languages:
 - Language: en
   Versions:
-  - Version: 2
+  - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20250317T155640Z
+      Value: 20251217T141118Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
-        sitecore\Admin
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
       Hint: __Created by
       Value: |
-        sitecore\Admin
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "a03b5024-f15c-4186-9906-8bec13669fef"
+      Value: "d98e4531-5fda-4f9e-8bdf-2f2dd750e03b"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T143231Z
+      Value: 20251217T141118Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Adjust search.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Adjust search.yml
@@ -1,0 +1,45 @@
+﻿---
+ID: "9c81d458-86e5-458b-b012-ae467ade4682"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Adjust search"
+SharedFields:
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_TryAdjustingYourSearch
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "cbcfa435-54c4-4d74-a03b-fc3729ef0681"
+Languages:
+- Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Try adjusting your search or clear it
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "cc46ef86-9715-4023-b07d-d3bf0e3594c6"
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T141323Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "bc783152-8868-408b-b548-2218b1d2ccc2"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T141343Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Clear search.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Clear search.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "42768340-fbe3-4edd-a925-7c13d13d4c02"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Clear search"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_ClearSearch
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "a0ce6ac3-4e51-4bfc-be0a-897e7118c9f6"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Clear search
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "77f74111-697e-4b0b-9b45-8f3a687b9d5d"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141355Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "0dd20c52-23cb-429c-a10c-2d40ec0d80d3"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141409Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Load more.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Load more.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "68686af3-923c-47ed-b2cc-7bb8c2dde4fe"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Load more"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_LoadMore
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "20d782ca-c267-4ab1-86ea-bb48c3f9dc97"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Load more
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "a511e844-87e8-4807-aba2-b152fec9f953"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141542Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "b60f4ff0-1d6b-4bea-a453-9a4cb6841e77"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141551Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Next page.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Next page.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "31871e44-5123-4f98-a607-81cf67f83350"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Next page"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_NextPage
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "7c0ddbe8-9af3-4964-b6a0-f77aa23be006"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Next
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "b69ea0d1-ec75-4856-9a1c-0adde7476f1f"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141650Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "fb2c161c-f3ef-4176-99f6-99d48d16ea24"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141658Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/No results found.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/No results found.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "dfa89aef-06d9-4054-be5c-349b89ed3ada"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/No results found"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_NoResultsFound
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "2aebe1ca-e322-498c-8178-c1ce74283651"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: No results found
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "ebb260e0-27a1-4fd7-b61c-1e7b4e8d586f"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141234Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "8cda8989-fd56-4daa-b8f6-55e474f39a5f"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141248Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Previous page.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Previous page.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "7c0ffd8e-ed8e-4193-9972-c4587695d9e8"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Previous page"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_PreviousPage
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "d0105552-167c-4f6d-93ef-45b85776e08f"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Previous
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "34ab27d6-e058-4880-82db-42bd998a756a"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141623Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "9c2b79e0-ca28-42cf-bdeb-e62c05192843"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141638Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Read more.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Read more.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "1d6bc524-5b57-4620-88b4-7829d235a540"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Read more"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_ReadMore
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "e1416b90-0121-44bd-b225-c7b53879e077"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Read More
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "eef68107-19e8-43b8-b29e-ba29d9898585"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141709Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "e82a8cce-1728-4485-89dd-3436f51fc484"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141727Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Results Found.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Results Found.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "8623d820-7a3d-4e1a-9394-16898d357140"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Results Found"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_ResultsFound
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "d88e25f3-36ea-410c-ae08-3747cf1a4929"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: results found
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "acaea7e3-5d3f-4cfc-b6ac-456f8fcedc60"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141203Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "18bb9e1c-7491-43b2-b106-2659d4cd2dfd"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141223Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Search input placeholder.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Search input placeholder.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "b8bf25a2-4a52-4ed7-9162-58b001958ea6"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Search input placeholder"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_SearchInputPlaceholder
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "402eb06b-a99b-4ff1-a498-d445d5e95c60"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Search items...
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "57ddbcf6-8b79-4824-8775-f76938c6e92e"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141602Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "189567cc-70c0-43b6-8af2-dcb4bca8105e"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141615Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Something went wrong.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Something went wrong.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "6742fe57-6329-43e8-aaac-ff885e135719"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Something went wrong"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_SomethingWentWrong
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "cd6c9594-bc47-4bdc-8a1b-f3d13ba4e0d8"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Something went wrong
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "3ac5846a-ae9d-4cf7-9f93-44174547bd34"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141419Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "1cd649a4-add5-4efc-adb1-b0986d9b1250"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141436Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Try again.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Try again.yml
@@ -1,29 +1,30 @@
 ﻿---
-ID: "55323273-a15d-4405-9a31-27abe188bcd8"
-Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
-Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+ID: "8eeacd22-686b-4952-80ab-74ce50a2b515"
+Parent: "12136754-a7f7-467c-80ad-243562e60925"
+Template: "6d1cd897-1936-4a3a-a511-289a94c2a7b1"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Add Dictionary Items/Search Experience/Try again"
 SharedFields:
-- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
-  Hint: Source
-  Value: "pub-958f3b66-0fb0-4675-8808-a5dc40949051"
-- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
-  Hint: Type
-  Value: Plugin
-- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
-  Hint: __Sortorder
-  Value: 100
+- ID: "580c75a8-c01a-4580-83cb-987776ceb3af"
+  Hint: Key
+  Value: SearchExperience_TryAgain
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "bf97002c-96ca-4933-ba6e-0e3de33b1752"
+  Value: "dfb18ab7-f9ae-4325-b287-7920744a3b2e"
 Languages:
 - Language: en
+  Fields:
+  - ID: "2ba3454a-9a9c-4cdf-a9f8-107fd484eb6e"
+    Hint: Phrase
+    Value: Try again
+  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
+    Hint: __Unversioned revision
+    Value: "86e39f1f-c5ef-41a6-9a34-591be7b9ab3e"
   Versions:
   - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20251217T065446Z
+      Value: 20251217T141444Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
@@ -34,11 +35,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "debddf81-bc14-454a-a237-3621e9309d16"
+      Value: "210c2a24-d1c5-4066-8d64-3739b55381df"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T141031Z
+      Value: 20251217T141456Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 10.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 10.yml
@@ -7,7 +7,7 @@ SharedFields:
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{BF1FF2C6-2CAD-4B04-BE71-D82E4FEF0FB5}" />
+    <image mediaid="{AB037694-C94B-435A-B36A-2A2F7C65FFA4}" />
 Languages:
 - Language: en
   Versions:
@@ -79,7 +79,10 @@ Languages:
         {711D9D90-6882-42C9-B1A3-AF95FB149D2F}
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fadc076e-0cb8-4834-bb66-26cf191d1b25"
+      Value: "aeae6e2b-07c6-44ee-94d2-98d71eca4a19"
+    - ID: "a6e61076-ae6c-4436-8dea-317b5405e54c"
+      Hint: Link
+      Value: "/speakers/heritage-10"
     - ID: "b041d971-f2fd-4514-95b8-7fc8a90cd41f"
       Hint: ShippingLink
       Value: |
@@ -87,13 +90,13 @@ Languages:
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\brandon.bruno@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d0de8ee1-e2cf-4abc-9729-51d602dbbfe2"
       Hint: AmpPower
       Value: 80AMPS
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250630T170837Z
+      Value: 20251217T143314Z
     - ID: "ea0a4ef8-eecd-472b-95a9-59c9f801494e"
       Hint: ProductImage
       Value: |

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 30.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 30.yml
@@ -7,7 +7,7 @@ SharedFields:
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{4BF77248-0D72-478A-A7C7-421C17DC0D92}" />
+    <image mediaid="{6BBF97E6-0B51-403C-8E37-56F16EDEFB47}" />
 Languages:
 - Language: en
   Versions:
@@ -83,7 +83,10 @@ Languages:
         {711D9D90-6882-42C9-B1A3-AF95FB149D2F}
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "a402ab47-f21a-46f8-adc4-8c1100fd7569"
+      Value: "5b5d678a-6b8d-4077-b48c-1b9f72bf3a11"
+    - ID: "a6e61076-ae6c-4436-8dea-317b5405e54c"
+      Hint: Link
+      Value: "/speakers/heritage-30"
     - ID: "b041d971-f2fd-4514-95b8-7fc8a90cd41f"
       Hint: ShippingLink
       Value: |
@@ -91,13 +94,13 @@ Languages:
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\brandon.bruno@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d0de8ee1-e2cf-4abc-9729-51d602dbbfe2"
       Hint: AmpPower
       Value: 100AMP or 80AMPS
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250630T170904Z
+      Value: 20251217T143326Z
     - ID: "ea0a4ef8-eecd-472b-95a9-59c9f801494e"
       Hint: ProductImage
       Value: |

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 50.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Add Speakers/Speakers/Heritage 50.yml
@@ -7,7 +7,7 @@ SharedFields:
 - ID: "c7c26117-dbb1-42b2-ab5e-f7223845cca3"
   Hint: __Thumbnail
   Value: |
-    <image mediaid="{36F33941-3A2B-4E80-9E42-E82FA7F06207}" />
+    <image mediaid="{88EC6C17-A227-4B11-ABB9-D5E559026B2A}" />
 Languages:
 - Language: en
   Versions:
@@ -91,7 +91,10 @@ Languages:
         {711D9D90-6882-42C9-B1A3-AF95FB149D2F}
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "a8b69989-d79c-4bb5-8784-f494d728d9ac"
+      Value: "a26aceb3-8fa9-4731-b743-639ed36358a4"
+    - ID: "a6e61076-ae6c-4436-8dea-317b5405e54c"
+      Hint: Link
+      Value: "/speakers/heritage-50"
     - ID: "b041d971-f2fd-4514-95b8-7fc8a90cd41f"
       Hint: ShippingLink
       Value: |
@@ -99,13 +102,13 @@ Languages:
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\brandon.bruno@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d0de8ee1-e2cf-4abc-9729-51d602dbbfe2"
       Hint: AmpPower
       Value: 100AMP or 80AMPS
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250630T171122Z
+      Value: 20251217T143334Z
     - ID: "ea0a4ef8-eecd-472b-95a9-59c9f801494e"
       Hint: ProductImage
       Value: |

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants.yml
@@ -1,0 +1,31 @@
+---
+ID: "9a579d3c-80ad-4105-b6da-127e5f9256f0"
+Parent: "d4a8dd36-7815-43c7-abfd-b412a9045f45"
+Template: "35e75c72-4985-4e09-88c3-0eac6cd1e64f"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Variants/Search Experience Headless Variants"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T073344Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "6ffddf9c-a1af-42ae-8307-5fa301854df1"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T073344Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience.yml
@@ -1,0 +1,31 @@
+---
+ID: "042520f8-6c13-4c21-b077-ae690714971b"
+Parent: "9a579d3c-80ad-4105-b6da-127e5f9256f0"
+Template: "49c111d0-6867-4798-a724-1f103166e6e9"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T073457Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "adfb8e68-a74f-4b62-bb1d-6a86f984053f"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T073457Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/Default.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/Default.yml
@@ -1,0 +1,31 @@
+---
+ID: "d148c661-e0df-42a8-a04e-81052b7e6c26"
+Parent: "042520f8-6c13-4c21-b077-ae690714971b"
+Template: "4d50cdae-c2d9-4de8-b080-8f992bfb1b55"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/Default"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T073520Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "88425d4a-dfbe-4bb8-8102-611d9f602333"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T073520Z

--- a/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/LoadMore.yml
+++ b/authoring/items/items/templates/items/ccl.templates.branches/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/LoadMore.yml
@@ -1,0 +1,31 @@
+---
+ID: "baf5f56f-e903-413f-a700-25435be542ec"
+Parent: "042520f8-6c13-4c21-b077-ae690714971b"
+Template: "4d50cdae-c2d9-4de8-b080-8f992bfb1b55"
+Path: "/sitecore/templates/Branches/Project/click-click-launch/SYNC/Variants/Search Experience Headless Variants/Search Experience/LoadMore"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T073526Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "f8ff3e04-3a8d-40fc-a69a-c47b5e7c671e"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T073526Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience.yml
@@ -1,0 +1,31 @@
+---
+ID: "9d2a143f-a725-46d4-b3f8-d3d484070826"
+Parent: "aca8d4ff-30c9-4d84-8778-f609664ed4d1"
+Template: "0437fee2-44c9-46a6-abe9-28858d9fee8c"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T061553Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "c6b05368-4046-44d9-a3b5-b517986afb78"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T061553Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters.yml
@@ -1,0 +1,31 @@
+---
+ID: "fea12d0a-22bd-4eb4-80c2-da6eb4705c7a"
+Parent: "9d2a143f-a725-46d4-b3f8-d3d484070826"
+Template: "0437fee2-44c9-46a6-abe9-28858d9fee8c"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Rendering Parameters"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062454Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "59677ebc-1a5c-4068-a9b6-6ea460338f47"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062454Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters.yml
@@ -1,0 +1,48 @@
+---
+ID: "bad0ef57-d3bf-4841-a7db-d6247f95f94a"
+Parent: "fea12d0a-22bd-4eb4-80c2-da6eb4705c7a"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters"
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Office/32x32/window_dialog.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Value: |
+    {4247AAD4-EBDE-4994-998F-E067A51B1FE4}
+    {5C74E985-E055-43FF-B28C-DB6C6A6450A2}
+    {44A022DB-56D3-419A-B43B-E27E4D8E9C41}
+    {3DB3EB10-F8D0-4CC9-BE26-18CE7B139EC8}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "2c22bcf2-9111-4275-ad02-f088462010cc"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{59DAB6EC-5246-4604-9FE1-A0AD13327F24}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062516Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "c2564523-756a-4325-9882-a92314ccc141"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T063256Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data.yml
@@ -1,0 +1,31 @@
+---
+ID: "f403ff0f-7474-4605-ad0f-668c8b67c552"
+Parent: "bad0ef57-d3bf-4841-a7db-d6247f95f94a"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T063240Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "785341bc-1f8b-47d8-b2ef-9efbb4bb7a48"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T065429Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data/columns.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data/columns.yml
@@ -1,0 +1,41 @@
+---
+ID: "2e7504a1-0207-433e-b3ad-b69892452969"
+Parent: "f403ff0f-7474-4605-ad0f-668c8b67c552"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/Data/columns"
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Number
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "4314869e-7ae3-4353-84ca-2ad974a33651"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T063240Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "e144f9ce-ad63-432d-9969-cff4120c1ec7"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T065429Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/__Standard Values.yml
@@ -1,0 +1,31 @@
+---
+ID: "59dab6ec-5246-4604-9fe1-a0ad13327f24"
+Parent: "bad0ef57-d3bf-4841-a7db-d6247f95f94a"
+Template: "bad0ef57-d3bf-4841-a7db-d6247f95f94a"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Rendering Parameters/Search Experience Parameters/__Standard Values"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T063256Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "4d5bc6f4-b416-4990-927c-1dcbcf8c993b"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T063256Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder.yml
@@ -1,0 +1,44 @@
+---
+ID: "ddec7923-74b5-4c0c-86a6-04f551123581"
+Parent: "9d2a143f-a725-46d4-b3f8-d3d484070826"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience Folder"
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Office/32x32/window_dialog.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "7285797c-a34c-4190-804e-f0362304b421"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{512C911C-473A-420F-BD79-4E484BE930B5}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062353Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "b5f1dae9-4277-43c6-8470-c391ce482bc0"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062438Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values.yml
@@ -1,0 +1,31 @@
+---
+ID: "512c911c-473a-420f-bd79-4e484be930b5"
+Parent: "ddec7923-74b5-4c0c-86a6-04f551123581"
+Template: "ddec7923-74b5-4c0c-86a6-04f551123581"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T062438Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "8b792521-1c38-4006-baf1-15f87b426922"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062438Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values.yml
@@ -1,8 +1,17 @@
----
+﻿---
 ID: "512c911c-473a-420f-bd79-4e484be930b5"
 Parent: "ddec7923-74b5-4c0c-86a6-04f551123581"
 Template: "ddec7923-74b5-4c0c-86a6-04f551123581"
 Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience Folder/__Standard Values"
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Value: |
+    {5A3D7AA7-0CB1-468A-9C8D-7BC02D6F110B}
+    {DDEC7923-74B5-4C0C-86A6-04F551123581}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "da8dfed1-9308-4ef5-a048-7ccbea5321f2"
 Languages:
 - Language: en
   Versions:
@@ -21,11 +30,11 @@ Languages:
         sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "8b792521-1c38-4006-baf1-15f87b426922"
+      Value: "138f67f3-78cd-4f2c-b6d5-7b0ae01f6894"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
         sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20251217T062438Z
+      Value: 20251218T100752Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience.yml
@@ -1,0 +1,46 @@
+---
+ID: "5a3d7aa7-0cb1-468a-9c8d-7bc02d6f110b"
+Parent: "9d2a143f-a725-46d4-b3f8-d3d484070826"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience"
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Office/32x32/window_dialog.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Value: |
+    {1930BBEB-7805-471A-A3BE-4858AC7CF696}
+    {44A022DB-56D3-419A-B43B-E27E4D8E9C41}
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "acf0d30b-67a3-45cb-9ea0-e6d37fecbfcf"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{4014784D-E445-4D83-B57A-AA8B77AA3C84}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T061720Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "af254bd6-b7f4-4719-a479-71b89074573a"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062215Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/Data.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/Data.yml
@@ -1,0 +1,31 @@
+---
+ID: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
+Parent: "5a3d7aa7-0cb1-468a-9c8d-7bc02d6f110b"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T065446Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "d6afec79-2d2c-4176-8b73-e8764b9c86ac"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T065446Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/Data/search.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/Data/search.yml
@@ -1,0 +1,44 @@
+---
+ID: "55323273-a15d-4405-9a31-27abe188bcd8"
+Parent: "d282a189-50eb-4fa8-9730-8f7f84ea4c65"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/Data/search"
+SharedFields:
+- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
+  Hint: Source
+  Value: test
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Plugin
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+- ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
+  Hint: __Shared revision
+  Value: "72a7b101-788c-4506-8aeb-b3cccd7f92ff"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T065446Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "1cab83fb-e57f-4640-b38e-2c017737fab6"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T065447Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/__Standard Values.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Components/Search Experience/Search Experience/__Standard Values.yml
@@ -1,0 +1,31 @@
+---
+ID: "4014784d-e445-4d83-b57a-aa8b77aa3c84"
+Parent: "5a3d7aa7-0cb1-468a-9c8d-7bc02d6f110b"
+Template: "5a3d7aa7-0cb1-468a-9c8d-7bc02d6f110b"
+Path: "/sitecore/templates/Project/click-click-launch/Components/Search Experience/Search Experience/__Standard Values"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20251217T061732Z
+    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
+      Hint: __Owner
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
+      Hint: __Revision
+      Value: "4f160fe1-61d7-4049-8c12-064654529bbe"
+    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
+      Hint: __Updated by
+      Value: |
+        sitecore\illia.kovalenko@sitecore.com
+    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
+      Hint: __Updated
+      Value: 20251217T062215Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Colors.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Colors.yml
@@ -29,29 +29,6 @@ Languages:
     Hint: __Display name
     Value: 
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250317T155640Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "b0bb5795-d179-4f41-9029-c638b8686146"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250317T155943Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -67,11 +44,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "55bc0048-d95d-4f7d-a4d9-44bb78eacfc3"
+      Value: "facb3b9b-8f9d-4b09-9939-6dfb95776c27"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250612T105106Z
+      Value: 20251217T143232Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Link.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Link.yml
@@ -1,47 +1,37 @@
 ﻿---
-ID: "ead05710-2521-4e01-89a6-25b24e209678"
+ID: "a6e61076-ae6c-4436-8dea-317b5405e54c"
 Parent: "cdbd0b40-5095-4522-8ba9-d6db6edaa66b"
 Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: "/sitecore/templates/Project/click-click-launch/Site/Audio Product Page/Product Details/Description"
+Path: "/sitecore/templates/Project/click-click-launch/Site/Audio Product Page/Product Details/Link"
 SharedFields:
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
-  Value: "Multi-Line Text"
+  Value: "Single-Line Text"
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
-  Value: 300
+  Value: 900
 - ID: "dbbbeca1-21c7-4906-9dd2-493c1efa59a2"
   Hint: __Shared revision
-  Value: "0d4a8cb7-5e15-407d-9640-ee5b349ae885"
+  Value: "b408ad2a-cddb-4199-9c01-e29730a4e8aa"
 Languages:
 - Language: en
-  Fields:
-  - ID: "19a69332-a23e-4e70-8d16-b2640cb24cc8"
-    Hint: Title
-    Value: Description
-  - ID: "30e85e5d-e00a-4864-b358-7624d511deb4"
-    Hint: __Unversioned revision
-    Value: "6e7537fa-6b6c-47f6-a516-b11076a16b6a"
-  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
-    Hint: __Display name
-    Value: 
   Versions:
-  - Version: 2
+  - Version: 1
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20250317T155640Z
+      Value: 20251217T142559Z
     - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
       Hint: __Owner
       Value: |
-        sitecore\Admin
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
       Hint: __Created by
       Value: |
-        sitecore\Admin
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "7a7215e4-33ee-40bf-9b68-e65baa8167b9"
+      Value: "71a023d7-3879-42e0-9751-764dfb5697fc"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Price.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/Price.yml
@@ -23,29 +23,6 @@ Languages:
     Hint: __Display name
     Value: 
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250317T155640Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "c71a45c5-68d3-4aca-a17c-d9147d06e567"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250317T155900Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -61,11 +38,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "fb0c496e-177d-4a56-8aa0-04b1ecfb8816"
+      Value: "4e7a4d91-996e-43bf-831a-347c5d1c6875"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250612T105106Z
+      Value: 20251217T143232Z

--- a/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/ProductName.yml
+++ b/authoring/items/items/templates/items/ccl.templates/click-click-launch/Site/Audio Product Page/Product Details/ProductName.yml
@@ -35,29 +35,6 @@ Languages:
     Hint: __Display name
     Value: 
   Versions:
-  - Version: 1
-    Fields:
-    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
-      Hint: __Created
-      Value: 20250317T155640Z
-    - ID: "52807595-0f8f-4b20-8d2a-cb71d28c6103"
-      Hint: __Owner
-      Value: |
-        sitecore\Admin
-    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
-      Hint: __Created by
-      Value: |
-        sitecore\Admin
-    - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
-      Hint: __Revision
-      Value: "e4a619ed-74ad-4edd-810f-3b3975f4f549"
-    - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
-      Hint: __Updated by
-      Value: |
-        sitecore\Admin
-    - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
-      Hint: __Updated
-      Value: 20250317T155742Z
   - Version: 2
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
@@ -73,11 +50,11 @@ Languages:
         sitecore\Admin
     - ID: "8cdc337e-a112-42fb-bbb4-4143751e123f"
       Hint: __Revision
-      Value: "ece7f3c3-9a6d-4c19-bfb7-fb52cd780331"
+      Value: "6c580dba-268a-4bbd-a7e5-c0a91680e947"
     - ID: "badd9cf9-53e0-4d0c-bcc0-2d784c282f6a"
       Hint: __Updated by
       Value: |
-        sitecore\neli.kostadinova@sitecore.com
+        sitecore\illia.kovalenko@sitecore.com
     - ID: "d9cf14b1-fa16-4ba6-9288-e8a174d4d522"
       Hint: __Updated
-      Value: 20250612T105106Z
+      Value: 20251217T143232Z

--- a/examples/kit-nextjs-product-listing/.sitecore/component-map.client.ts
+++ b/examples/kit-nextjs-product-listing/.sitecore/component-map.client.ts
@@ -30,6 +30,8 @@ import * as AccordionBlock from 'src/components/site-three/AccordionBlock';
 import * as SearchBox from 'src/components/site-three/non-sitecore/SearchBox';
 import * as MiniCart from 'src/components/site-three/non-sitecore/MiniCart';
 import * as SecondaryNavigation from 'src/components/secondary-navigation/SecondaryNavigation';
+import * as SearchExperienceLoadMore from 'src/components/search-experience/SearchExperience.LoadMore';
+import * as SearchExperience from 'src/components/search-experience/SearchExperience';
 import * as PromoAnimatedImageRightdev from 'src/components/promo-animated/PromoAnimatedImageRight.dev';
 import * as PromoAnimatedDefaultdev from 'src/components/promo-animated/PromoAnimatedDefault.dev';
 import * as PromoAnimated from 'src/components/promo-animated/PromoAnimated';
@@ -127,6 +129,7 @@ export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['SearchBox', { ...SearchBox }],
   ['MiniCart', { ...MiniCart }],
   ['SecondaryNavigation', { ...SecondaryNavigation }],
+  ['SearchExperience', { ...SearchExperienceLoadMore, ...SearchExperience }],
   ['PromoAnimatedImageRight', { ...PromoAnimatedImageRightdev }],
   ['PromoAnimatedDefault', { ...PromoAnimatedDefaultdev }],
   ['PromoAnimated', { ...PromoAnimated }],

--- a/examples/kit-nextjs-product-listing/.sitecore/component-map.ts
+++ b/examples/kit-nextjs-product-listing/.sitecore/component-map.ts
@@ -64,6 +64,8 @@ import * as SiteMetadata from 'src/components/site-metadata/SiteMetadata';
 import * as sitemetadataprops from 'src/components/site-metadata/site-metadata.props';
 import * as SecondaryNavigation from 'src/components/secondary-navigation/SecondaryNavigation';
 import * as secondarynavigationprops from 'src/components/secondary-navigation/secondary-navigation.props';
+import * as SearchExperienceLoadMore from 'src/components/search-experience/SearchExperience.LoadMore';
+import * as SearchExperience from 'src/components/search-experience/SearchExperience';
 import * as RichTextBlock from 'src/components/rich-text-block/RichTextBlock';
 import * as richtextblockprops from 'src/components/rich-text-block/rich-text-block.props';
 import * as PromoImageTitlePartialOverlaydev from 'src/components/promo-image/PromoImageTitlePartialOverlay.dev';
@@ -300,6 +302,7 @@ export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['site-metadata', { ...sitemetadataprops }],
   ['SecondaryNavigation', { ...SecondaryNavigation, componentType: 'client' }],
   ['secondary-navigation', { ...secondarynavigationprops }],
+  ['SearchExperience', { ...SearchExperienceLoadMore, ...SearchExperience, componentType: 'client' }],
   ['RichTextBlock', { ...RichTextBlock }],
   ['rich-text-block', { ...richtextblockprops }],
   ['PromoImageTitlePartialOverlay', { ...PromoImageTitlePartialOverlaydev }],

--- a/examples/kit-nextjs-product-listing/sitecore.cli.config.ts
+++ b/examples/kit-nextjs-product-listing/sitecore.cli.config.ts
@@ -22,6 +22,15 @@ export default defineCliConfig({
   componentMap: {
     paths: ['src/components'],
     // Exclude content-sdk auxillary components
-    exclude: ['src/components/content-sdk/*', 'src/components/ui/*', 'src/components/lib/*', 'src/components/video/*', 'src/components/multi-promo/*', 'src/components/image-carousel/*', 'src/components/accordion-block/*'],
+    exclude: [
+      'src/components/content-sdk/*',
+      'src/components/ui/*',
+      'src/components/lib/*',
+      'src/components/video/*',
+      'src/components/multi-promo/*',
+      'src/components/image-carousel/*',
+      'src/components/accordion-block/*',
+      'src/components/search-experience/search-components/**/*',
+    ],
   },
 });

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
@@ -1,0 +1,152 @@
+'use client';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useSitecore } from '@sitecore-content-sdk/nextjs';
+import { useInfiniteSearch } from '@sitecore-content-sdk/nextjs/search';
+import { cn } from 'lib/utils';
+import { SearchDocument, SearchExperienceProps } from './search-components/models';
+import { SearchEmptyResults } from './search-components/SearchEmptyResults';
+import { SearchError } from './search-components/SearchError';
+import { SearchItem } from './search-components/SearchItem';
+import { SearchSkeletonItem } from './search-components/SearchSkeletonItem';
+import { SearchInput } from './search-components/SearchInput';
+import { useEvent } from './search-components/useEvent';
+import { useSearchField } from './search-components/useSearchField';
+import { DICTIONARY_KEYS, gridColsClass } from './search-components/constants';
+import { useParams } from './search-components/useParams';
+import { useRouter } from './search-components/useRouter';
+
+export const LoadMore = (props: SearchExperienceProps) => {
+  const { page } = useSitecore();
+  const { params } = props;
+  const t = useTranslations();
+  const { searchIndex, fieldsMapping } = useSearchField(props.fields.search.value);
+
+  const { styles, id, pageSize, columns } = useParams(params);
+
+  const { isEditing, isPreview } = page.mode;
+  const [inputValue, setInputValue] = useState<string>('');
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [searchEnabled, setSearchEnabled] = useState<boolean>(false);
+  const isInitializedRef = useRef<boolean>(false);
+
+  const {
+    total,
+    loadMore,
+    results,
+    isLoading,
+    isLoadingMore,
+    error,
+    isError,
+    isSuccess,
+    hasNextPage,
+  } = useInfiniteSearch<SearchDocument>({
+    searchIndexId: searchIndex,
+    pageSize,
+    enabled: searchEnabled,
+    query: searchQuery,
+  });
+
+  const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
+
+  const { setRouterQuery, router } = useRouter();
+
+  useEffect(() => {
+    if (isSuccess) {
+      sendEvent('viewed');
+    }
+  }, [isSuccess, sendEvent]);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    const routerQuery = (router.query.q as string) || '';
+
+    setSearchQuery(routerQuery);
+  }, [router.isReady, inputValue, router.query.q]);
+
+  useEffect(() => {
+    if (!router.isReady || isEditing || isPreview) return;
+
+    if (!isInitializedRef.current) {
+      // Enable the search and set the input value from the router query on initial load
+      setSearchEnabled(true);
+      setInputValue(router.query.q as string);
+      isInitializedRef.current = true;
+    }
+  }, [router.isReady, router.query.q, isEditing, isPreview]);
+
+  const onSearchChange = useCallback(
+    (value: string, debounced: boolean = true) => {
+      setInputValue(value);
+
+      if (isEditing || isPreview) return;
+
+      setRouterQuery(value, debounced);
+    },
+    [setRouterQuery, isEditing, isPreview]
+  );
+
+  return (
+    <div className={`component search-indexing ${styles}`} id={id ? id : undefined}>
+      <div className="component-content">
+        <div className="max-w-7xl mx-auto p-6">
+          <div className="mb-8">
+            <SearchInput value={inputValue} onChange={(value) => onSearchChange(value, true)} />
+
+            <p className="text-gray-600 mb-6">
+              {total} {t(DICTIONARY_KEYS.RESULTS_FOUND) || 'results found'}
+            </p>
+          </div>
+
+          {isError && error && (
+            <SearchError error={error} onTryAgain={() => onSearchChange('', false)} />
+          )}
+
+          {!isLoading && !isError && total === 0 && (
+            <SearchEmptyResults
+              query={searchQuery}
+              onClearSearch={() => onSearchChange('', false)}
+            />
+          )}
+
+          <div className={cn('grid gap-6 mb-8', gridColsClass(columns))}>
+            {!isLoading &&
+              results.map((result) => (
+                <SearchItem
+                  variant={columns === 1 ? 'list' : 'card'}
+                  key={result.sc_item_id}
+                  data={result}
+                  mapping={fieldsMapping}
+                  onClick={() => sendEvent('clicked')}
+                />
+              ))}
+
+            {(((isEditing || isPreview) && total === 0) || isLoading) &&
+              Array.from({ length: pageSize }).map((_, index) => (
+                <SearchSkeletonItem
+                  variant={columns === 1 ? 'list' : 'card'}
+                  key={index}
+                  mapping={fieldsMapping}
+                />
+              ))}
+          </div>
+
+          {hasNextPage && (
+            <div className="flex justify-center items-center">
+              <button
+                onClick={() => {
+                  loadMore();
+                }}
+                disabled={isLoadingMore}
+                className="px-4 py-2 rounded-lg cursor-pointer bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50"
+              >
+                {t(DICTIONARY_KEYS.LOAD_MORE) || 'Load more'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useSitecore } from '@sitecore-content-sdk/nextjs';
@@ -24,12 +24,12 @@ export const LoadMore = (props: SearchExperienceProps) => {
   const { searchIndex, fieldsMapping } = useSearchField(props.fields.search.value);
 
   const { styles, id, pageSize, columns } = useParams(params);
+  const searchParams = useSearchParams();
 
   const { isEditing, isPreview } = page.mode;
-  const [inputValue, setInputValue] = useState<string>('');
+  const [inputValue, setInputValue] = useState<string>((searchParams.get('q') as string) || '');
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [searchEnabled, setSearchEnabled] = useState<boolean>(false);
-  const isInitializedRef = useRef<boolean>(false);
 
   const {
     total,
@@ -49,7 +49,6 @@ export const LoadMore = (props: SearchExperienceProps) => {
   });
 
   const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
-  const searchParams = useSearchParams();
 
   const { setRouterQuery } = useRouter();
 
@@ -63,18 +62,13 @@ export const LoadMore = (props: SearchExperienceProps) => {
     const routerQuery = (searchParams.get('q') as string) || '';
 
     setSearchQuery(routerQuery);
-  }, [inputValue, searchParams]);
+  }, [searchParams]);
 
   useEffect(() => {
     if (isEditing || isPreview) return;
 
-    if (!isInitializedRef.current) {
-      // Enable the search and set the input value from the router query on initial load
-      setSearchEnabled(true);
-      setInputValue(searchParams.get('q') as string);
-      isInitializedRef.current = true;
-    }
-  }, [searchParams, isEditing, isPreview]);
+    setSearchEnabled(true);
+  }, [isEditing, isPreview]);
 
   const onSearchChange = useCallback(
     (value: string, debounced: boolean = true) => {

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
 import { useSitecore } from '@sitecore-content-sdk/nextjs';
 import { useInfiniteSearch } from '@sitecore-content-sdk/nextjs/search';
 import { cn } from 'lib/utils';
@@ -48,8 +49,9 @@ export const LoadMore = (props: SearchExperienceProps) => {
   });
 
   const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
+  const searchParams = useSearchParams();
 
-  const { setRouterQuery, router } = useRouter();
+  const { setRouterQuery } = useRouter();
 
   useEffect(() => {
     if (isSuccess) {
@@ -58,23 +60,21 @@ export const LoadMore = (props: SearchExperienceProps) => {
   }, [isSuccess, sendEvent]);
 
   useEffect(() => {
-    if (!router.isReady) return;
-
-    const routerQuery = (router.query.q as string) || '';
+    const routerQuery = (searchParams.get('q') as string) || '';
 
     setSearchQuery(routerQuery);
-  }, [router.isReady, inputValue, router.query.q]);
+  }, [inputValue, searchParams]);
 
   useEffect(() => {
-    if (!router.isReady || isEditing || isPreview) return;
+    if (isEditing || isPreview) return;
 
     if (!isInitializedRef.current) {
       // Enable the search and set the input value from the router query on initial load
       setSearchEnabled(true);
-      setInputValue(router.query.q as string);
+      setInputValue(searchParams.get('q') as string);
       isInitializedRef.current = true;
     }
-  }, [router.isReady, router.query.q, isEditing, isPreview]);
+  }, [searchParams, isEditing, isPreview]);
 
   const onSearchChange = useCallback(
     (value: string, debounced: boolean = true) => {

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.LoadMore.tsx
@@ -84,7 +84,11 @@ export const LoadMore = (props: SearchExperienceProps) => {
   return (
     <div className={`component search-indexing ${styles}`} id={id ? id : undefined}>
       <div className="component-content">
-        <div className="max-w-7xl mx-auto p-6">
+        <div
+          className={cn('max-w-7xl mx-auto p-6', {
+            'pt-24 lg:pt-32': !isEditing,
+          })}
+        >
           <div className="mb-8">
             <SearchInput value={inputValue} onChange={(value) => onSearchChange(value, true)} />
 

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useSitecore } from '@sitecore-content-sdk/nextjs';
@@ -26,13 +26,13 @@ export const Default = (props: SearchExperienceProps) => {
   const { searchIndex, fieldsMapping } = useSearchField(props.fields.search.value);
 
   const { styles, id, pageSize, columns } = useParams(params);
+  const searchParams = useSearchParams();
 
   const { isEditing, isPreview } = page.mode;
   const [pageNumber, setPageNumber] = useState(1);
-  const [inputValue, setInputValue] = useState<string>('');
+  const [inputValue, setInputValue] = useState<string>((searchParams.get('q') as string) || '');
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [searchEnabled, setSearchEnabled] = useState<boolean>(false);
-  const isInitializedRef = useRef<boolean>(false);
 
   const { total, totalPages, results, isLoading, isSuccess, isError, error } =
     useSearch<SearchDocument>({
@@ -44,7 +44,6 @@ export const Default = (props: SearchExperienceProps) => {
     });
 
   const { setRouterQuery } = useRouter();
-  const searchParams = useSearchParams();
 
   const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
 
@@ -62,18 +61,13 @@ export const Default = (props: SearchExperienceProps) => {
     if (!routerQuery) {
       setPageNumber(1);
     }
-  }, [inputValue, searchParams]);
+  }, [searchParams]);
 
   useEffect(() => {
     if (isEditing || isPreview) return;
 
-    if (!isInitializedRef.current) {
-      // Enable the search and set the input value from the router query on initial load
-      setSearchEnabled(true);
-      setInputValue(searchParams.get('q') as string);
-      isInitializedRef.current = true;
-    }
-  }, [searchParams, isEditing, isPreview]);
+    setSearchEnabled(true);
+  }, [isEditing, isPreview]);
 
   const onSearchChange = useCallback(
     (value: string, debounced: boolean = true) => {

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
@@ -1,0 +1,145 @@
+'use client';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useSitecore } from '@sitecore-content-sdk/nextjs';
+import { useSearch } from '@sitecore-content-sdk/nextjs/search';
+import { cn } from 'lib/utils';
+import { SearchDocument, SearchExperienceProps } from './search-components/models';
+import { SearchEmptyResults } from './search-components/SearchEmptyResults';
+import { SearchError } from './search-components/SearchError';
+import { SearchItem } from './search-components/SearchItem';
+import { SearchSkeletonItem } from './search-components/SearchSkeletonItem';
+import { SearchPagination } from './search-components/SearchPagination';
+import { SearchInput } from './search-components/SearchInput';
+import { useEvent } from './search-components/useEvent';
+import { useSearchField } from './search-components/useSearchField';
+import { useParams } from './search-components/useParams';
+import { DICTIONARY_KEYS, gridColsClass } from './search-components/constants';
+import { useRouter } from './search-components/useRouter';
+
+export const Default = (props: SearchExperienceProps) => {
+  const { page } = useSitecore();
+  const { params } = props;
+  const t = useTranslations();
+
+  const { searchIndex, fieldsMapping } = useSearchField(props.fields.search.value);
+
+  const { styles, id, pageSize, columns } = useParams(params);
+
+  const { isEditing, isPreview } = page.mode;
+  const [pageNumber, setPageNumber] = useState(1);
+  const [inputValue, setInputValue] = useState<string>('');
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [searchEnabled, setSearchEnabled] = useState<boolean>(false);
+  const isInitializedRef = useRef<boolean>(false);
+
+  const { total, totalPages, results, isLoading, isSuccess, isError, error } =
+    useSearch<SearchDocument>({
+      searchIndexId: searchIndex,
+      page: pageNumber,
+      pageSize,
+      enabled: searchEnabled,
+      query: searchQuery,
+    });
+
+  const { setRouterQuery, router } = useRouter();
+
+  const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
+
+  useEffect(() => {
+    if (isSuccess) {
+      sendEvent('viewed');
+    }
+  }, [isSuccess, sendEvent]);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    const routerQuery = (router.query.q as string) || '';
+
+    setSearchQuery(routerQuery);
+
+    if (!routerQuery) {
+      setPageNumber(1);
+    }
+  }, [router.isReady, inputValue, router.query.q]);
+
+  useEffect(() => {
+    if (!router.isReady || isEditing || isPreview) return;
+
+    if (!isInitializedRef.current) {
+      // Enable the search and set the input value from the router query on initial load
+      setSearchEnabled(true);
+      setInputValue(router.query.q as string);
+      isInitializedRef.current = true;
+    }
+  }, [router.isReady, router.query.q, isEditing, isPreview]);
+
+  const onSearchChange = useCallback(
+    (value: string, debounced: boolean = true) => {
+      setInputValue(value);
+
+      if (isEditing || isPreview) return;
+
+      setRouterQuery(value, debounced);
+    },
+    [setRouterQuery, isEditing, isPreview]
+  );
+
+  return (
+    <div className={`component search-indexing ${styles}`} id={id ? id : undefined}>
+      <div className="component-content">
+        <div className="max-w-7xl mx-auto p-6">
+          <div className="mb-8">
+            <SearchInput value={inputValue} onChange={(value) => onSearchChange(value, true)} />
+
+            <p className="text-gray-600 mb-6">
+              {total} {t(DICTIONARY_KEYS.RESULTS_FOUND) || 'results found'}
+            </p>
+          </div>
+
+          {isError && error && (
+            <SearchError error={error} onTryAgain={() => onSearchChange('', false)} />
+          )}
+
+          {!isLoading && !isError && total === 0 && (
+            <SearchEmptyResults
+              query={searchQuery}
+              onClearSearch={() => onSearchChange('', false)}
+            />
+          )}
+
+          <div className={cn('grid gap-6 mb-8', gridColsClass(columns))}>
+            {!isLoading &&
+              results.map((result) => (
+                <SearchItem
+                  variant={columns === 1 ? 'list' : 'card'}
+                  key={result.sc_item_id}
+                  data={result}
+                  mapping={fieldsMapping}
+                  onClick={() => sendEvent('clicked')}
+                />
+              ))}
+
+            {(((isEditing || isPreview) && total === 0) || isLoading) &&
+              Array.from({ length: pageSize }).map((_, index) => (
+                <SearchSkeletonItem
+                  variant={params.columns === 1 ? 'list' : 'card'}
+                  key={index}
+                  mapping={fieldsMapping}
+                />
+              ))}
+          </div>
+
+          {!isLoading && !isError && results.length > 0 && (
+            <SearchPagination
+              currentPage={pageNumber}
+              totalPages={totalPages}
+              onPageChange={(page: number) => setPageNumber(page)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
@@ -83,7 +83,11 @@ export const Default = (props: SearchExperienceProps) => {
   return (
     <div className={`component search-indexing ${styles}`} id={id ? id : undefined}>
       <div className="component-content">
-        <div className="max-w-7xl mx-auto p-6">
+        <div
+          className={cn('max-w-7xl mx-auto p-6', {
+            'pt-24 lg:pt-32': !isEditing,
+          })}
+        >
           <div className="mb-8">
             <SearchInput value={inputValue} onChange={(value) => onSearchChange(value, true)} />
 

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/SearchExperience.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
 import { useSitecore } from '@sitecore-content-sdk/nextjs';
 import { useSearch } from '@sitecore-content-sdk/nextjs/search';
 import { cn } from 'lib/utils';
@@ -42,7 +43,8 @@ export const Default = (props: SearchExperienceProps) => {
       query: searchQuery,
     });
 
-  const { setRouterQuery, router } = useRouter();
+  const { setRouterQuery } = useRouter();
+  const searchParams = useSearchParams();
 
   const sendEvent = useEvent({ query: searchQuery, uid: props.rendering.uid });
 
@@ -53,27 +55,25 @@ export const Default = (props: SearchExperienceProps) => {
   }, [isSuccess, sendEvent]);
 
   useEffect(() => {
-    if (!router.isReady) return;
-
-    const routerQuery = (router.query.q as string) || '';
+    const routerQuery = (searchParams.get('q') as string) || '';
 
     setSearchQuery(routerQuery);
 
     if (!routerQuery) {
       setPageNumber(1);
     }
-  }, [router.isReady, inputValue, router.query.q]);
+  }, [inputValue, searchParams]);
 
   useEffect(() => {
-    if (!router.isReady || isEditing || isPreview) return;
+    if (isEditing || isPreview) return;
 
     if (!isInitializedRef.current) {
       // Enable the search and set the input value from the router query on initial load
       setSearchEnabled(true);
-      setInputValue(router.query.q as string);
+      setInputValue(searchParams.get('q') as string);
       isInitializedRef.current = true;
     }
-  }, [router.isReady, router.query.q, isEditing, isPreview]);
+  }, [searchParams, isEditing, isPreview]);
 
   const onSearchChange = useCallback(
     (value: string, debounced: boolean = true) => {

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchEmptyResults.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchEmptyResults.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useTranslations } from 'next-intl';
+import { DICTIONARY_KEYS } from './constants';
+
+export const SearchEmptyResults = ({
+  query,
+  onClearSearch,
+}: {
+  query: string;
+  onClearSearch: () => void;
+}) => {
+  const t = useTranslations();
+
+  return (
+    <div className="mb-8">
+      <div className="bg-white border border-gray-200 rounded-lg p-12 text-center">
+        <svg
+          className="mx-auto h-10 w-10 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <h3 className="mt-4 text-lg font-semibold text-gray-900">
+          {t(DICTIONARY_KEYS.NO_RESULTS_FOUND) || 'No results found'}
+        </h3>
+        <p className="mt-2 text-gray-600">
+          {t(DICTIONARY_KEYS.TRY_ADJUSTING_YOUR_SEARCH) || 'Try adjusting your search or clear it.'}
+        </p>
+        <div className="mt-6">
+          <button
+            onClick={onClearSearch}
+            disabled={!query}
+            className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary-hover disabled:opacity-50"
+          >
+            {t(DICTIONARY_KEYS.CLEAR_SEARCH) || 'Clear search'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchError.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchError.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useTranslations } from 'next-intl';
+import { DICTIONARY_KEYS } from './constants';
+
+export const SearchError = ({ onTryAgain, error }: { onTryAgain: () => void; error: Error }) => {
+  const t = useTranslations();
+
+  return (
+    <div className="mb-8">
+      <div className="bg-white border border-red-200 rounded-lg p-12 text-center">
+        <svg
+          className="mx-auto h-10 w-10 text-red-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01M5.07 19h13.86A2 2 0 0021 17.15L13.93 4.85a2 2 0 00-3.86 0L3 17.15A2 2 0 005.07 19z"
+          />
+        </svg>
+        <h3 className="mt-4 text-lg font-semibold text-gray-900">
+          {t(DICTIONARY_KEYS.SOMETHING_WENT_WRONG) || 'Something went wrong'}
+        </h3>
+        <p className="mt-2 text-gray-600">{error.message}</p>
+        <div className="mt-6">
+          <button
+            onClick={onTryAgain}
+            className="px-4 py-2 rounded-md bg-red-600 text-white cursor-pointer"
+          >
+            {t(DICTIONARY_KEYS.TRY_AGAIN) || 'Try again'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchInput.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchInput.tsx
@@ -1,0 +1,57 @@
+'use client';
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { DICTIONARY_KEYS } from './constants';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (query: string) => void;
+}
+
+export const SearchInput = ({ value, onChange }: SearchInputProps) => {
+  const t = useTranslations();
+
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6 mb-6">
+      <div className="relative flex-1">
+        <input
+          type="text"
+          placeholder={t(DICTIONARY_KEYS.SEARCH_INPUT_PLACEHOLDER) || 'Search items...'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full px-4 py-3 pl-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+        <svg
+          className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        {value && (
+          <button
+            type="button"
+            onClick={() => onChange('')}
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400 hover:text-gray-600 focus:outline-none focus:text-gray-600 transition-colors"
+            aria-label="Clear search"
+          >
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemCategory.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemCategory.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { Text } from '@sitecore-content-sdk/nextjs';
+import { cn } from 'lib/utils';
+
+type SearchItemCategoryProps = {
+  category: { value: string } | undefined;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const SearchItemCategory = ({ category, className, ...props }: SearchItemCategoryProps) => {
+  return (
+    category && (
+      <div className={cn('flex flex-wrap gap-2 mb-4', className)} {...props}>
+        <Text
+          field={category}
+          tag="span"
+          className="px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded"
+        />
+      </div>
+    )
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemLink.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemLink.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@sitecore-content-sdk/nextjs';
+import { cn } from 'lib/utils';
+import { SearchItemFields } from './index';
+import { DICTIONARY_KEYS } from '../constants';
+
+type SearchItemLinkProps = {
+  link: SearchItemFields['title'];
+  onClick: () => void;
+} & HTMLAttributes<HTMLAnchorElement>;
+
+export const SearchItemLink = ({ className, link, onClick, ...props }: SearchItemLinkProps) => {
+  const t = useTranslations();
+
+  return (
+    link && (
+      <Link
+        field={{ href: link.value }}
+        className={cn(
+          'inline-flex items-center text-primary hover:text-primary-hover font-medium',
+          className
+        )}
+        onClick={onClick}
+        {...props}
+      >
+        {t(DICTIONARY_KEYS.READ_MORE) || 'Read More'}
+        <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </Link>
+    )
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemSubTitle.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemSubTitle.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { Text } from '@sitecore-content-sdk/nextjs';
+import { cn } from 'lib/utils';
+import { SearchItemFields } from './index';
+
+type SearchItemTitleProps = {
+  text: SearchItemFields['subTitle'];
+} & HTMLAttributes<HTMLHeadingElement>;
+
+export const SearchItemSubTitle = ({ className, text, ...props }: SearchItemTitleProps) => {
+  return (
+    text && (
+      <h3
+        className={cn('text-base font-light text-gray-900 mb-3 line-clamp-2', className)}
+        {...props}
+      >
+        <Text field={text} />
+      </h3>
+    )
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemSummary.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemSummary.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { Text } from '@sitecore-content-sdk/nextjs';
+import { cn } from 'lib/utils';
+import { SearchItemFields } from './index';
+
+type SearchItemSummaryProps = {
+  summary: SearchItemFields['summary'];
+} & HTMLAttributes<HTMLParagraphElement>;
+
+export const SearchItemSummary = ({ className, summary, ...props }: SearchItemSummaryProps) => {
+  return (
+    summary && (
+      <p className={cn('text-gray-600 mb-4', className)} {...props}>
+        <Text field={summary} />
+      </p>
+    )
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemTitle.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/SearchItemTitle.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { Text } from '@sitecore-content-sdk/nextjs';
+import { cn } from 'lib/utils';
+import { SearchItemFields } from './index';
+
+type SearchItemTitleProps = {
+  text: SearchItemFields['title'];
+} & HTMLAttributes<HTMLHeadingElement>;
+
+export const SearchItemTitle = ({ className, text, ...props }: SearchItemTitleProps) => {
+  return (
+    text && (
+      <h3
+        className={cn('text-xl font-semibold text-gray-900 mb-3 line-clamp-2', className)}
+        {...props}
+      >
+        <Text field={text} />
+      </h3>
+    )
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/index.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItem/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { HTMLAttributes, useMemo } from 'react';
+import { Field } from '@sitecore-content-sdk/nextjs';
+import { ItemCardFrame, ItemListFrame, SearchItemVariant } from '../SearchItemCommon';
+import { SearchDocument, SearchFieldsMapping } from '../models';
+import { SearchItemTitle } from './SearchItemTitle';
+import { SearchItemSummary } from './SearchItemSummary';
+import { SearchItemLink } from './SearchItemLink';
+import { SearchItemSubTitle } from './SearchItemSubTitle';
+import { SearchItemCategory } from './SearchItemCategory';
+
+export type SearchItemFields = {
+  summary?: Field<string>;
+  category?: Field<string>;
+  title?: Field<string>;
+  subTitle?: Field<string>;
+  link?: Field<string>;
+};
+
+type SearchItemProps = {
+  data: SearchDocument;
+  mapping: SearchFieldsMapping;
+  variant?: SearchItemVariant;
+  onClick: () => void;
+} & HTMLAttributes<HTMLDivElement>;
+
+const getField = (
+  fields: { [key: string]: string },
+  key: keyof SearchDocument
+): { value: string } | undefined => {
+  if (!key) return undefined;
+  const k = String(key);
+  if (typeof fields?.[k] !== 'string') return undefined;
+  return { value: fields[k] } as { value: string };
+};
+
+export const SearchItem = ({ data, mapping, variant = 'card', onClick }: SearchItemProps) => {
+  const isCard = variant === 'card';
+
+  const fields = useMemo((): SearchItemFields => {
+    const title = mapping.title ? getField(data, mapping.title) : undefined;
+    return {
+      title,
+      subTitle: getField(data, 'Price'),
+      summary: mapping.description ? getField(data, mapping.description) : undefined,
+      category: mapping.type ? getField(data, mapping.type) : undefined,
+      link: mapping.link ? getField(data, mapping.link) : undefined,
+    };
+  }, [data, mapping]);
+
+  const components = (
+    <>
+      {fields.category && (
+        <SearchItemCategory category={fields.category} className="line-clamp-2" />
+      )}
+      {fields.title && <SearchItemTitle text={fields.title} className="line-clamp-2" />}
+      {fields.subTitle && <SearchItemSubTitle text={fields.subTitle} className="line-clamp-2" />}
+      {fields.summary && <SearchItemSummary summary={fields.summary} className="line-clamp-3" />}
+      {fields.link && <SearchItemLink link={fields.link} onClick={onClick} />}
+    </>
+  );
+
+  return isCard ? (
+    <ItemCardFrame>{components}</ItemCardFrame>
+  ) : (
+    <ItemListFrame>{components}</ItemListFrame>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItemCommon.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchItemCommon.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { cn } from 'lib/utils';
+
+export type SearchItemVariant = 'card' | 'list';
+
+type ItemListFrameProps = HTMLAttributes<HTMLDivElement>;
+
+export const ItemListFrame = ({ className, children, ...props }: ItemListFrameProps) => {
+  return (
+    <div
+      className={cn(
+        'bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow cursor-pointer md:h-57',
+        className
+      )}
+      {...props}
+    >
+      <div className={cn('flex flex-col md:flex-row w-full h-full')}>
+        <div className="p-6 md:flex-1">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+type ItemCardFrameProps = HTMLAttributes<HTMLDivElement>;
+
+export const ItemCardFrame = ({ className, children, ...props }: ItemCardFrameProps) => {
+  return (
+    <div
+      className={cn(
+        'bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow cursor-pointer',
+        className
+      )}
+      {...props}
+    >
+      <div className="p-6">{children}</div>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchPagination.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchPagination.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { useTranslations } from 'next-intl';
+import { DICTIONARY_KEYS } from './constants';
+
+export const SearchPagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) => {
+  const t = useTranslations();
+  const maxVisiblePages = 3;
+
+  // Determine the window of pages to display (max of 3)
+  let startPage = Math.max(1, currentPage - 1);
+  let endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+
+  // Adjust start when near the end to keep the window size consistent
+  startPage = Math.max(1, Math.min(startPage, Math.max(1, endPage - maxVisiblePages + 1)));
+
+  // Recalculate endPage based on (possibly) adjusted startPage
+  endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+
+  const pages: number[] = [];
+  for (let p = startPage; p <= endPage; p++) {
+    pages.push(p);
+  }
+
+  const showLeftEllipsis = startPage > 1;
+  const showRightEllipsis = endPage < totalPages;
+
+  return (
+    <div className="flex justify-center items-center gap-2">
+      <button
+        onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+        disabled={currentPage === 1}
+        className="flex items-center gap-1 px-3 py-2 rounded-lg cursor-pointer text-gray-600 hover:bg-primary-hover hover:text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        {t(DICTIONARY_KEYS.PREVIOUS_PAGE) || 'Previous'}
+      </button>
+
+      {showLeftEllipsis && (
+        <span
+          key="left-ellipsis"
+          className="w-10 h-10 flex items-center justify-center text-gray-400 select-none"
+          aria-hidden
+        >
+          …
+        </span>
+      )}
+
+      {pages.map((page) => (
+        <button
+          key={page}
+          onClick={() => onPageChange(page)}
+          className={`w-10 h-10 rounded-lg cursor-pointer hover:bg-primary-hover hover:text-primary-foreground ${
+            currentPage === page
+              ? 'bg-primary text-primary-foreground'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          {page}
+        </button>
+      ))}
+
+      {showRightEllipsis && (
+        <span
+          key="right-ellipsis"
+          className="w-10 h-10 flex items-center justify-center text-gray-400 select-none"
+          aria-hidden
+        >
+          …
+        </span>
+      )}
+
+      <button
+        onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
+        disabled={currentPage === totalPages}
+        className="flex items-center gap-1 px-3 py-2 rounded-lg cursor-pointer text-gray-600 hover:bg-primary-hover hover:text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {t(DICTIONARY_KEYS.NEXT_PAGE) || 'Next'}
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchSkeletonItem.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/SearchSkeletonItem.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import { cn } from 'lib/utils';
+import { ItemCardFrame, ItemListFrame, SearchItemVariant } from './SearchItemCommon';
+import { SearchFieldsMapping } from './models';
+
+type SearchSkeletonItemProps = {
+  mapping: SearchFieldsMapping;
+  variant?: SearchItemVariant;
+} & HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Renders a skeleton item in Editing
+ */
+export const SearchSkeletonItem = ({ mapping, variant = 'card' }: SearchSkeletonItemProps) => {
+  const isCard = variant === 'card';
+
+  const fields = (
+    <>
+      {mapping.type && <SearchItemCategorySkeleton />}
+      {mapping.title && <SearchItemTitleSkeleton />}
+      {mapping.description && <SearchItemSummarySkeleton />}
+      {mapping.link && <SearchItemLinkSkeleton />}
+    </>
+  );
+
+  return isCard ? <ItemCardFrame>{fields}</ItemCardFrame> : <ItemListFrame>{fields}</ItemListFrame>;
+};
+
+const SearchItemTitleSkeleton = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div className={cn('h-6 w-3/4 bg-gray-200 rounded mb-3 animate-pulse', className)} {...props} />
+  );
+};
+
+const SearchItemSummarySkeleton = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div className={cn('space-y-2 mb-4', className)} {...props}>
+      <div className="h-4 w-full bg-gray-200 rounded animate-pulse" />
+      <div className="h-4 w-5/6 bg-gray-200 rounded animate-pulse" />
+    </div>
+  );
+};
+
+const SearchItemLinkSkeleton = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return <div className={cn('h-5 w-24 bg-gray-200 rounded animate-pulse', className)} {...props} />;
+};
+
+const SearchItemCategorySkeleton = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div className={cn('h-6 w-1/4 bg-gray-200 rounded mb-3 animate-pulse', className)} {...props} />
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/constants.ts
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/constants.ts
@@ -1,0 +1,42 @@
+/**
+ * The default debounce time for the search experience
+ */
+export const DEBOUNCE_TIME = 400;
+
+/**
+ * The default page size for the search experience
+ */
+export const DEFAULT_PAGE_SIZE = 6;
+
+/**
+ * Returns the grid class for the number of columns
+ * @param value - The number of columns to return the grid class for
+ * @returns The grid class for the number of columns
+ */
+export const gridColsClass = (value = 3): string => {
+  const cols = Number(value) || 3;
+  const map: Record<number, string> = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-2',
+    3: 'grid-cols-3',
+  };
+
+  const baseClass = map[Math.max(1, Math.min(cols, 3))];
+
+  // Always use 1 column on mobile, then apply the configured columns from md breakpoint
+  return `grid-cols-1 md:${baseClass}`;
+};
+
+export const DICTIONARY_KEYS = {
+  RESULTS_FOUND: 'SearchExperience_ResultsFound',
+  NO_RESULTS_FOUND: 'SearchExperience_NoResultsFound',
+  TRY_ADJUSTING_YOUR_SEARCH: 'SearchExperience_TryAdjustingYourSearch',
+  CLEAR_SEARCH: 'SearchExperience_ClearSearch',
+  SOMETHING_WENT_WRONG: 'SearchExperience_SomethingWentWrong',
+  TRY_AGAIN: 'SearchExperience_TryAgain',
+  LOAD_MORE: 'SearchExperience_LoadMore',
+  SEARCH_INPUT_PLACEHOLDER: 'SearchExperience_SearchInputPlaceholder',
+  PREVIOUS_PAGE: 'SearchExperience_PreviousPage',
+  NEXT_PAGE: 'SearchExperience_NextPage',
+  READ_MORE: 'SearchExperience_ReadMore',
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/models.ts
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/models.ts
@@ -1,0 +1,48 @@
+import { ComponentParams, ComponentRendering } from '@sitecore-content-sdk/nextjs';
+
+export type SearchParams = ComponentParams & {
+  columns?: number;
+  pageSize?: number;
+  styles?: string;
+  GridParameters?: string;
+  RenderingIdentifier?: string;
+};
+
+export type SearchDocument = {
+  sc_item_id: string;
+  Description: string;
+  Price: string;
+  ProductName: string;
+  AmpPower: string;
+  Link: string;
+};
+
+type SearchDocumentKey = keyof SearchDocument;
+
+/**
+ * Mapping of the component fields to the search index fields
+ */
+export interface SearchFieldsMapping {
+  description?: SearchDocumentKey;
+  type?: SearchDocumentKey;
+  title?: SearchDocumentKey;
+  link?: SearchDocumentKey;
+}
+
+export interface SearchField {
+  searchIndex: string;
+  fieldsMapping: SearchFieldsMapping;
+}
+
+export interface SearchExperienceProps {
+  params: SearchParams;
+  fields: {
+    /**
+     * JSON stringified object of type SearchField
+     */
+    search: {
+      value: string;
+    };
+  };
+  rendering: ComponentRendering;
+}

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useDebounce.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useDebounce.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useCallback, useRef } from 'react';
+import { DEBOUNCE_TIME } from './constants';
+
+/**
+ * This hook is used to debounce a callback.
+ */
+export const useDebouncedCallback = <T extends unknown[]>(
+  cb: (...args: T) => void,
+  delay: number = DEBOUNCE_TIME
+) => {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  return useCallback(
+    (...args: T) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => cb(...args), delay);
+    },
+    [cb, delay]
+  );
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useEvent.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useEvent.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useCallback } from 'react';
+import { useSitecore } from '@sitecore-content-sdk/nextjs';
+import { event } from '@sitecore-cloudsdk/events/browser';
+
+/**
+ * This hook is used to send events to SitecoreCloud.
+ */
+export const useEvent = ({ query, uid }: { query: string; uid?: string }) => {
+  const { page } = useSitecore();
+  const { isEditing, isPreview } = page.mode;
+  const { route } = page?.layout?.sitecore;
+
+  const sendEvent = useCallback(
+    (type: 'clicked' | 'viewed') => {
+      if (process.env.NODE_ENV === 'development' || isEditing || isPreview) return;
+
+      event({
+        type: 'search',
+        siteId: page.siteName,
+        channel: 'web',
+        name: route?.name,
+        language: route?.itemLanguage,
+        core: {
+          componentId: uid ?? '',
+          interactionType: type,
+          keyword: query ?? '',
+          nullResults: false,
+        },
+      });
+    },
+    [route, page, uid, query, isEditing, isPreview]
+  );
+
+  return sendEvent;
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useParams.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useParams.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { DEFAULT_PAGE_SIZE } from './constants';
+import { SearchParams } from './models';
+
+export const useParams = (params: SearchParams) => {
+  const containerStyles = params.styles ?? '';
+  const styles = `${params.GridParameters} ${containerStyles}`.trimEnd();
+  const id = params.RenderingIdentifier;
+  const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+
+  return {
+    styles,
+    id,
+    pageSize,
+    columns: params.columns,
+  };
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useRouter.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useRouter.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useCallback } from 'react';
+import { useRouter as useNextRouter } from 'next/router';
+import { useDebouncedCallback } from './useDebounce';
+
+export const useRouter = () => {
+  const router = useNextRouter();
+  const setRouterQuery = useCallback(
+    (value: string) => {
+      if (value) {
+        router.query.q = value;
+      } else {
+        delete router.query.q;
+      }
+
+      // Construct the URL with current pathname to avoid exposing rewrites
+      const currentPath = router.asPath.split('?')[0];
+      const queryString = router.query.q ? `?q=${router.query.q}` : '';
+      const asPath = currentPath + queryString;
+
+      router.replace({ query: router.query }, asPath, { shallow: true });
+    },
+    [router]
+  );
+
+  const debouncedSetRouterQuery = useDebouncedCallback(setRouterQuery);
+
+  const setQuery = useCallback(
+    (value: string, debounced: boolean = true) => {
+      if (debounced) {
+        debouncedSetRouterQuery(value);
+      } else {
+        setRouterQuery(value);
+      }
+    },
+    [debouncedSetRouterQuery, setRouterQuery]
+  );
+
+  return { setRouterQuery: setQuery, router };
+};

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useRouter.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useRouter.tsx
@@ -1,26 +1,21 @@
 'use client';
 import { useCallback } from 'react';
-import { useRouter as useNextRouter } from 'next/router';
+import { useRouter as useNextRouter, usePathname } from 'next/navigation';
 import { useDebouncedCallback } from './useDebounce';
 
 export const useRouter = () => {
   const router = useNextRouter();
+  const pathname = usePathname();
   const setRouterQuery = useCallback(
     (value: string) => {
-      if (value) {
-        router.query.q = value;
-      } else {
-        delete router.query.q;
-      }
-
       // Construct the URL with current pathname to avoid exposing rewrites
-      const currentPath = router.asPath.split('?')[0];
-      const queryString = router.query.q ? `?q=${router.query.q}` : '';
+      const currentPath = pathname.split('?')[0];
+      const queryString = value ? `?q=${value}` : '';
       const asPath = currentPath + queryString;
 
-      router.replace({ query: router.query }, asPath, { shallow: true });
+      router.replace(asPath);
     },
-    [router]
+    [router, pathname]
   );
 
   const debouncedSetRouterQuery = useDebouncedCallback(setRouterQuery);
@@ -36,5 +31,5 @@ export const useRouter = () => {
     [debouncedSetRouterQuery, setRouterQuery]
   );
 
-  return { setRouterQuery: setQuery, router };
+  return { setRouterQuery: setQuery };
 };

--- a/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useSearchField.tsx
+++ b/examples/kit-nextjs-product-listing/src/components/search-experience/search-components/useSearchField.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useMemo } from 'react';
+import { SearchField } from './models';
+
+/**
+ * Parses the component search field
+ */
+export const useSearchField = (value: string) => {
+  const { searchIndex, fieldsMapping } = useMemo((): SearchField => {
+    try {
+      return JSON.parse(value) as SearchField;
+    } catch (error) {
+      console.error('Error parsing search field', error);
+      return { searchIndex: '', fieldsMapping: {} };
+    }
+  }, [value]);
+
+  return { searchIndex, fieldsMapping };
+};


### PR DESCRIPTION
Fixes the search page content being overlapped by the fixed navigation header in preview/production mode.


## Description / Motivation
Added conditional top padding to the `SearchExperience` component that:
- Only applies when **not** in editing mode (where the header is already in normal document flow)
- Uses responsive padding (`pt-24` for mobile, `lg:pt-32` for desktop) to account for the 96px fixed header height

## Changes
- `src/components/search-experience/SearchExperience.tsx` - Added conditional padding based on `isEditing` state
- `src/components/search-experience/SearchExperience.LoadMore.tsx` - Applied the same fix for consistency

## Related
Affects: `kit-nextjs-product-listing` starter

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

*Explain how to test this PR. Include specific areas to test, relevant test cases, and any setup required.*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Terms
<!-- Place an `x` in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
