### PR TITLE
Integrate geo test into DMZ Validation workflow

### DIFF
--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -583,6 +583,13 @@ jobs:
           echo "Running GEO endpoint tests (site must be running)..."
           echo "Per-starter site names: skate-park | solterra | alaris | sync (must match build and exist in XM Cloud)"
 
+          # Why site names are hardcoded below: Each starter maps to the canonical Sitecore site name used by that
+          # kit in the All Things JSS / xmcloud-starter-js repo.
+          # GitHub Actions repository variables/secrets usually expose only ONE default NEXT_PUBLIC_DEFAULT_SITE_NAME;
+          # applying that single value to every starter would inline the wrong site into builds and break GEO tests.
+          # Whenever a site name changes in XM Cloud or in this repository, update the case arms to match — do not
+          # rely on the lone repo variable for per-kit site selection.
+
           # Fully stop the previous Next.js server and free :3000 before starting the next starter
           # (npm spawns child processes; killing only $! can leave node listening on the port)
           stop_geo_server() {
@@ -616,6 +623,7 @@ jobs:
                   stop_geo_server "$SERVER_PID"
                   SERVER_PID=""
 
+                  # sync | solterra | alaris | skate-park — must match XM Cloud + All Things JSS kit (see comment above).
                   case "$starter" in
                     examples/kit-nextjs-product-listing)
                       export NEXT_PUBLIC_DEFAULT_SITE_NAME="sync"
@@ -634,31 +642,24 @@ jobs:
                       ;;
                   esac
                   echo "NEXT_PUBLIC_DEFAULT_SITE_NAME=${NEXT_PUBLIC_DEFAULT_SITE_NAME}"
-                  # Build this starter here so .next matches this site (NEXT_PUBLIC_* inlined per starter).
-                  # Avoids relying on an earlier global build / wrong baked-in site name.
-                  echo "Building $starter for GEO (same env as main build)..."
-                  if ! npm run build; then
-                    echo "❌ GEO pre-build failed for $starter"
-                    cd ../..
-                    exit 1
-                  fi
-                  echo "Starting production server for GEO..."
-                  npm run next:start &
+                  # npm run start runs build then next:start (kit package.json). Allow time below for build before :3000 is up.
+                  echo "Starting $starter for GEO (npm run start)..."
+                  npm run start &
                   SERVER_PID=$!
   
-                  # Wait for server to be ready (max 60s)
+                  # Wait for server (npm run start runs build first; large starters may need several minutes)
                   echo "Waiting for server on http://localhost:3000..."
-                  for i in $(seq 1 30); do
+                  for i in $(seq 1 120); do
                     if curl -sf -o /dev/null http://localhost:3000 2>/dev/null; then
                       echo "Server ready."
                       break
                     fi
-                    if [ "$i" -eq 30 ]; then
+                    if [ "$i" -eq 120 ]; then
                       echo "❌ Server did not become ready in time"
                       stop_geo_server "$SERVER_PID"
                       exit 1
                     fi
-                    sleep 2
+                    sleep 5
                   done
   
                   if GEO_BASE_URL=http://localhost:3000 npm run test:geo; then

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -576,12 +576,39 @@ jobs:
           echo "Running GEO endpoint tests (site must be running)..."
           echo "Per-starter site names: skate-park | solterra | alaris | sync (must match build and exist in XM Cloud)"
 
+          # Fully stop the previous Next.js server and free :3000 before starting the next starter
+          # (npm spawns child processes; killing only $! can leave node listening on the port)
+          stop_geo_server() {
+            local pid="${1:-}"
+            echo "Stopping GEO server (pid=${pid:-none})..."
+            if [ -n "$pid" ]; then
+              kill "$pid" 2>/dev/null || true
+              pkill -P "$pid" 2>/dev/null || true
+            fi
+            pkill -f "next start" 2>/dev/null || true
+            sleep 2
+            for i in $(seq 1 20); do
+              if ! curl -sf -o /dev/null --connect-timeout 1 --max-time 3 http://127.0.0.1:3000/ 2>/dev/null; then
+                echo "Port 3000 is free."
+                return 0
+              fi
+              echo "Waiting for port 3000 to be released ($i/20)..."
+              fuser -k 3000/tcp 2>/dev/null || true
+              sleep 2
+            done
+            echo "⚠️ Port 3000 may still be in use; attempting to continue."
+          }
+
+          SERVER_PID=""
           for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
               if [ -d "$starter" ]; then
                 echo "GEO tests for $starter..."
                 cd "$starter"
   
                 if grep -q '"test:geo"' package.json 2>/dev/null; then
+                  stop_geo_server "$SERVER_PID"
+                  SERVER_PID=""
+
                   case "$starter" in
                     examples/kit-nextjs-product-listing)
                       export NEXT_PUBLIC_DEFAULT_SITE_NAME="sync"
@@ -613,7 +640,7 @@ jobs:
                     fi
                     if [ "$i" -eq 30 ]; then
                       echo "❌ Server did not become ready in time"
-                      kill $SERVER_PID 2>/dev/null || true
+                      stop_geo_server "$SERVER_PID"
                       exit 1
                     fi
                     sleep 2
@@ -623,13 +650,14 @@ jobs:
                     echo "✅ GEO tests passed for $starter"
                   else
                     echo "❌ GEO tests failed for $starter"
-                    kill $SERVER_PID 2>/dev/null || true
+                    stop_geo_server "$SERVER_PID"
+                    SERVER_PID=""
                     cd ../..
                     exit 1
                   fi
   
-                  kill $SERVER_PID 2>/dev/null || true
-                  sleep 2
+                  stop_geo_server "$SERVER_PID"
+                  SERVER_PID=""
                 else
                   echo "⏭️ No test:geo script for $starter, skipping"
                 fi
@@ -637,6 +665,7 @@ jobs:
                 cd ../..
               fi
             done
+            stop_geo_server "$SERVER_PID"
 
       - name: Create success notification
         if: success()

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -237,9 +237,9 @@ jobs:
           echo "Running GEO endpoint tests (site must be running)..."
 
           for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
-              if [ -d "examples/$starter" ]; then
+              if [ -d "$starter" ]; then
                 echo "GEO tests for $starter..."
-                cd "examples/$starter"
+                cd "$starter"
   
                 if grep -q '"test:geo"' package.json 2>/dev/null; then
                   # Start production server in background (build already done)

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -627,8 +627,10 @@ jobs:
                       ;;
                   esac
                   echo "NEXT_PUBLIC_DEFAULT_SITE_NAME=${NEXT_PUBLIC_DEFAULT_SITE_NAME}"
-                  # Start production server in background (build already done; site must match per-starter build)
-                  npm run start &
+                  # Use next:start only — kit starters' "start" script runs `build` then next:start, so `npm run start`
+                  # would rebuild (no listener on :3000 until build finishes) and often exceed the wait timeout;
+                  # the Build step above already produced .next for each starter.
+                  npm run next:start &
                   SERVER_PID=$!
   
                   # Wait for server to be ready (max 60s)

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Run tests
         run: |
-          set -e  # Exit immediately if any command fails
+          #set -e  # Exit immediately if any command fails
           echo "Running tests for all starters..."
 
           # Test each enabled starter
@@ -225,6 +225,60 @@ jobs:
               cd ../..
             fi
           done
+
+      - name: Run GEO endpoint tests (with server)
+        id: run-geo-tests
+        env:
+          SITECORE_EDGE_URL: ${{ secrets.SITECORE_EDGE_URL }}
+          SITECORE_EDGE_CONTEXT_ID: ${{ secrets.SITECORE_EDGE_CONTEXT_ID }}
+          NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID: ${{ secrets.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID }}
+          NEXT_PUBLIC_DEFAULT_SITE_NAME: ${{ vars.NEXT_PUBLIC_DEFAULT_SITE_NAME || 'basic' }}
+        run: |
+          echo "Running GEO endpoint tests (site must be running)..."
+
+          for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
+              if [ -d "examples/$starter" ]; then
+                echo "GEO tests for $starter..."
+                cd "examples/$starter"
+  
+                if grep -q '"test:geo"' package.json 2>/dev/null; then
+                  # Start production server in background (build already done)
+                  npm run start &
+                  SERVER_PID=$!
+  
+                  # Wait for server to be ready (max 60s)
+                  echo "Waiting for server on http://localhost:3000..."
+                  for i in $(seq 1 30); do
+                    if curl -sf -o /dev/null http://localhost:3000 2>/dev/null; then
+                      echo "Server ready."
+                      break
+                    fi
+                    if [ "$i" -eq 30 ]; then
+                      echo "❌ Server did not become ready in time"
+                      kill $SERVER_PID 2>/dev/null || true
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+  
+                  if GEO_BASE_URL=http://localhost:3000 npm run test:geo; then
+                    echo "✅ GEO tests passed for $starter"
+                  else
+                    echo "❌ GEO tests failed for $starter"
+                    kill $SERVER_PID 2>/dev/null || true
+                    cd ../..
+                    exit 1
+                  fi
+  
+                  kill $SERVER_PID 2>/dev/null || true
+                  sleep 2
+                else
+                  echo "⏭️ No test:geo script for $starter, skipping"
+                fi
+  
+                cd ../..
+              fi
+            done
 
       - name: Create success notification
         if: success()

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -574,6 +574,7 @@ jobs:
           NEXT_PUBLIC_DEFAULT_SITE_NAME: ${{ vars.NEXT_PUBLIC_DEFAULT_SITE_NAME || 'basic' }}
         run: |
           echo "Running GEO endpoint tests (site must be running)..."
+          echo "Per-starter site names: skate-park | solterra | alaris | sync (must match build and exist in XM Cloud)"
 
           for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
               if [ -d "$starter" ]; then
@@ -581,7 +582,25 @@ jobs:
                 cd "$starter"
   
                 if grep -q '"test:geo"' package.json 2>/dev/null; then
-                  # Start production server in background (build already done)
+                  case "$starter" in
+                    examples/kit-nextjs-product-listing)
+                      export NEXT_PUBLIC_DEFAULT_SITE_NAME="sync"
+                      ;;
+                    examples/kit-nextjs-article-starter)
+                      export NEXT_PUBLIC_DEFAULT_SITE_NAME="solterra"
+                      ;;
+                    examples/kit-nextjs-location-finder)
+                      export NEXT_PUBLIC_DEFAULT_SITE_NAME="alaris"
+                      ;;
+                    examples/kit-nextjs-skate-park)
+                      export NEXT_PUBLIC_DEFAULT_SITE_NAME="skate-park"
+                      ;;
+                    *)
+                      export NEXT_PUBLIC_DEFAULT_SITE_NAME="${NEXT_PUBLIC_DEFAULT_SITE_NAME:-basic}"
+                      ;;
+                  esac
+                  echo "NEXT_PUBLIC_DEFAULT_SITE_NAME=${NEXT_PUBLIC_DEFAULT_SITE_NAME}"
+                  # Start production server in background (build already done; site must match per-starter build)
                   npm run start &
                   SERVER_PID=$!
   

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -572,6 +572,13 @@ jobs:
           SITECORE_EDGE_CONTEXT_ID: ${{ secrets.SITECORE_EDGE_CONTEXT_ID }}
           NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID: ${{ secrets.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID }}
           NEXT_PUBLIC_DEFAULT_SITE_NAME: ${{ vars.NEXT_PUBLIC_DEFAULT_SITE_NAME || 'basic' }}
+          SITECORE_EDITING_SECRET: ${{ secrets.SITECORE_EDITING_SECRET }}
+          NEXT_PUBLIC_SITECORE_EDGE_URL: ${{ secrets.SITECORE_EDGE_URL }}
+          NEXT_PUBLIC_SITECORE_API_KEY: ${{ secrets.NEXT_PUBLIC_SITECORE_API_KEY }}
+          NEXT_PUBLIC_SITECORE_API_HOST: ${{ secrets.NEXT_PUBLIC_SITECORE_API_HOST }}
+          NEXT_PUBLIC_DEFAULT_LANGUAGE: ${{ vars.NEXT_PUBLIC_DEFAULT_LANGUAGE || 'en' }}
+          NEXT_PUBLIC_PERSONALIZE_SCOPE: ${{ vars.NEXT_PUBLIC_PERSONALIZE_SCOPE }}
+          PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT: ${{ vars.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT || '1000' }}
         run: |
           echo "Running GEO endpoint tests (site must be running)..."
           echo "Per-starter site names: skate-park | solterra | alaris | sync (must match build and exist in XM Cloud)"
@@ -627,9 +634,15 @@ jobs:
                       ;;
                   esac
                   echo "NEXT_PUBLIC_DEFAULT_SITE_NAME=${NEXT_PUBLIC_DEFAULT_SITE_NAME}"
-                  # Use next:start only — kit starters' "start" script runs `build` then next:start, so `npm run start`
-                  # would rebuild (no listener on :3000 until build finishes) and often exceed the wait timeout;
-                  # the Build step above already produced .next for each starter.
+                  # Build this starter here so .next matches this site (NEXT_PUBLIC_* inlined per starter).
+                  # Avoids relying on an earlier global build / wrong baked-in site name.
+                  echo "Building $starter for GEO (same env as main build)..."
+                  if ! npm run build; then
+                    echo "❌ GEO pre-build failed for $starter"
+                    cd ../..
+                    exit 1
+                  fi
+                  echo "Starting production server for GEO..."
                   npm run next:start &
                   SERVER_PID=$!
   

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -576,9 +576,9 @@ jobs:
           echo "Running GEO endpoint tests (site must be running)..."
 
           for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
-              if [ -d "examples/$starter" ]; then
+              if [ -d "$starter" ]; then
                 echo "GEO tests for $starter..."
-                cd "examples/$starter"
+                cd "$starter"
   
                 if grep -q '"test:geo"' package.json 2>/dev/null; then
                   # Start production server in background (build already done)

--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -565,6 +565,60 @@ jobs:
       #       fi
       #     done
 
+      - name: Run GEO endpoint tests (with server)
+        id: run-geo-tests
+        env:
+          SITECORE_EDGE_URL: ${{ secrets.SITECORE_EDGE_URL }}
+          SITECORE_EDGE_CONTEXT_ID: ${{ secrets.SITECORE_EDGE_CONTEXT_ID }}
+          NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID: ${{ secrets.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID }}
+          NEXT_PUBLIC_DEFAULT_SITE_NAME: ${{ vars.NEXT_PUBLIC_DEFAULT_SITE_NAME || 'basic' }}
+        run: |
+          echo "Running GEO endpoint tests (site must be running)..."
+
+          for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
+              if [ -d "examples/$starter" ]; then
+                echo "GEO tests for $starter..."
+                cd "examples/$starter"
+  
+                if grep -q '"test:geo"' package.json 2>/dev/null; then
+                  # Start production server in background (build already done)
+                  npm run start &
+                  SERVER_PID=$!
+  
+                  # Wait for server to be ready (max 60s)
+                  echo "Waiting for server on http://localhost:3000..."
+                  for i in $(seq 1 30); do
+                    if curl -sf -o /dev/null http://localhost:3000 2>/dev/null; then
+                      echo "Server ready."
+                      break
+                    fi
+                    if [ "$i" -eq 30 ]; then
+                      echo "❌ Server did not become ready in time"
+                      kill $SERVER_PID 2>/dev/null || true
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+  
+                  if GEO_BASE_URL=http://localhost:3000 npm run test:geo; then
+                    echo "✅ GEO tests passed for $starter"
+                  else
+                    echo "❌ GEO tests failed for $starter"
+                    kill $SERVER_PID 2>/dev/null || true
+                    cd ../..
+                    exit 1
+                  fi
+  
+                  kill $SERVER_PID 2>/dev/null || true
+                  sleep 2
+                else
+                  echo "⏭️ No test:geo script for $starter, skipping"
+                fi
+  
+                cd ../..
+              fi
+            done
+
       - name: Create success notification
         if: success()
         run: |

--- a/examples/kit-nextjs-article-starter/package.json
+++ b/examples/kit-nextjs-article-starter/package.json
@@ -157,10 +157,10 @@
     "start": "cross-env-shell NODE_ENV=production npm-run-all --serial build next:start",
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=geo",
-    "test:geo": "jest --testPathPatterns=geo",
+    "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:geo:watch": "jest --watch --testPathPatterns=geo",
+    "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }
 }

--- a/examples/kit-nextjs-location-finder/package.json
+++ b/examples/kit-nextjs-location-finder/package.json
@@ -146,10 +146,10 @@
     "start": "cross-env-shell NODE_ENV=production npm-run-all --serial build next:start",
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=geo",
-    "test:geo": "jest --testPathPatterns=geo",
+    "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:geo:watch": "jest --watch --testPathPatterns=geo",
+    "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }
 }

--- a/examples/kit-nextjs-product-listing/package.json
+++ b/examples/kit-nextjs-product-listing/package.json
@@ -142,10 +142,10 @@
   "scripts": {
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=geo",
-    "test:geo": "jest --testPathPatterns=geo",
+    "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:geo:watch": "jest --watch --testPathPatterns=geo",
+    "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage",
     "fix": "npm-run-all --serial lint:fix prettier",
     "lint:fix": "eslint ./src/**/*.tsx ./src/**/*.ts --fix",

--- a/examples/kit-nextjs-skate-park/package.json
+++ b/examples/kit-nextjs-skate-park/package.json
@@ -68,10 +68,10 @@
     "start": "cross-env-shell NODE_ENV=production npm-run-all --serial build next:start",
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=geo",
-    "test:geo": "jest --testPathPatterns=geo",
+    "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:geo:watch": "jest --watch --testPathPatterns=geo",
+    "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }
 }


### PR DESCRIPTION
PR: DMZ – GEO endpoint tests (with server)
Adds a Run GEO endpoint tests (with server) step to dmz-validation.yml: for each kit with test:geo, start the app (npm run start), wait for :3000, run GEO_BASE_URL=http://localhost:3000 npm run test:geo, then stop the server before the next kit.

Why: Validates robots/sitemaps/AI JSON against a running production server and XM Cloud. Per-starter NEXT_PUBLIC_DEFAULT_SITE_NAME is set in the workflow so a single repo variable doesn’t break multi-kit GEO.

Note: Site names in the workflow should stay aligned with XM Cloud / starter kits when they change