### PR TITLE
Enable "Run tests with coverage for all starters" in pr-validation and dmz-validation

### DIFF
--- a/.github/workflows/dmz-validation.yml
+++ b/.github/workflows/dmz-validation.yml
@@ -533,37 +533,36 @@ jobs:
           echo "::error::Build skipped - Missing required XM Cloud credentials in upstream repository"
           exit 1
 
-      # TODO: Uncomment this step after verifying credential issue is resolved
-      # - name: Run tests with coverage
-      #   if: steps.credential-check.outputs.credentials-valid == 'true'
-      #   run: |
-      #     set -e  # Exit immediately if any command fails
-      #     echo "Running tests with coverage for all starters..."
-      #
-      #     # Test each enabled starter
-      #     for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
-      #       if [ -d "$starter" ]; then
-      #         echo "Testing $starter..."
-      #         cd "$starter"
-      #         
-      #         # Check if test:coverage script exists, if not fail the workflow
-      #         if grep -q '"test:coverage"' package.json; then
-      #           echo "Running tests with coverage for $starter..."
-      #           if ! npm run test:coverage; then
-      #             echo "❌ Tests failed for $starter"
-      #             echo "::error::Tests failed for $starter"
-      #             exit 1
-      #           fi
-      #           echo "✅ Tests passed for $starter"
-      #         else
-      #           echo "❌ No test:coverage script found for $starter - tests are mandatory"
-      #           echo "::error::No test:coverage script found for $starter"
-      #           exit 1
-      #         fi
-      #
-      #         cd ../..
-      #       fi
-      #     done
+      - name: Run tests with coverage
+        if: steps.credential-check.outputs.credentials-valid == 'true'
+        run: |
+          set -e  # Exit immediately if any command fails
+          echo "Running tests with coverage for all starters..."
+
+          # Test each enabled starter
+          for starter in examples/kit-nextjs-skate-park examples/kit-nextjs-article-starter examples/kit-nextjs-location-finder examples/kit-nextjs-product-listing; do
+            if [ -d "$starter" ]; then
+              echo "Testing $starter..."
+              cd "$starter"
+
+              # Check if test:coverage script exists, if not fail the workflow
+              if grep -q '"test:coverage:unit"' package.json; then
+                echo "Running tests with coverage for $starter..."
+                if ! npm run test:coverage:unit; then
+                  echo "❌ Tests failed for $starter"
+                  echo "::error::Tests failed for $starter"
+                  exit 1
+                fi
+                echo "✅ Tests passed for $starter"
+              else
+                echo "❌ No test:coverage:unit script found for $starter - tests are mandatory"
+                echo "::error::No test:coverage:unit script found for $starter"
+                exit 1
+              fi
+
+              cd ../..
+            fi
+          done
 
       - name: Create success notification
         if: success()
@@ -573,7 +572,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Validation Results:**" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ All builds passed" >> $GITHUB_STEP_SUMMARY
-          echo "- ⏭️ Test execution with coverage (temporarily disabled for credential verification)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Unit tests with coverage (npm run test:coverage:unit)" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Linting and formatting checks passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Type checking passed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -599,7 +598,7 @@ jobs:
           echo "- 🔐 **Missing XM Cloud credentials in upstream repository** (check 'Validate XM Cloud credentials' step)" >> $GITHUB_STEP_SUMMARY
           echo "- Site configuration error: Site name mismatch (check 'Check configured site names' step)" >> $GITHUB_STEP_SUMMARY
           echo "- Build failures (check 'Build all starters' step)" >> $GITHUB_STEP_SUMMARY
-          echo "- ⏭️ Test execution (temporarily disabled for credential verification)" >> $GITHUB_STEP_SUMMARY
+          echo "- Unit tests with coverage (check 'Run tests with coverage:unit for all starters' step)" >> $GITHUB_STEP_SUMMARY
           echo "- Code quality issues (linting, formatting, type checking)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**⚠️ IMPORTANT - Credential Issue:**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -352,47 +352,46 @@ jobs:
           echo "ℹ️ Note: Full Next.js build with Sitecore integration will run"
           echo "   when this PR is reviewed in the upstream repository."
 
-      # TODO: Uncomment this step after verifying TypeScript compilation fix works
-      # - name: Run tests with coverage for all starters
-      #   env:
-      #     # Provide mock values for tests (in case they need Sitecore config)
-      #     SITECORE_EDGE_CONTEXT_ID: "mock-context-id-for-ci-tests"
-      #     NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID: "mock-context-id-for-ci-tests"
-      #     SITECORE_EDGE_URL: "https://edge.sitecorecloud.io"
-      #     NEXT_PUBLIC_SITECORE_EDGE_URL: "https://edge.sitecorecloud.io"
-      #     NEXT_PUBLIC_DEFAULT_SITE_NAME: "basic"
-      #     NEXT_PUBLIC_DEFAULT_LANGUAGE: "en"
-      #     SITECORE_EDITING_SECRET: "mock-editing-secret-for-ci-tests"
-      #   run: |
-      #     set -e  # Exit immediately if any command fails
-      #     echo "Running tests with coverage for all starters..."
-      #
-      #     # Test all enabled starters
-      #     for starter in kit-nextjs-skate-park kit-nextjs-article-starter kit-nextjs-location-finder kit-nextjs-product-listing; do
-      #       if [ -d "examples/$starter" ]; then
-      #         echo "=================================="
-      #         echo "Testing $starter"
-      #         echo "=================================="
-      #         cd "examples/$starter"
-      #         
-      #         # Check if test:coverage script exists
-      #         if grep -q '"test:coverage"' package.json; then
-      #           echo "Running tests with coverage for $starter..."
-      #           if ! npm run test:coverage; then
-      #             echo "❌ Tests failed for $starter"
-      #             echo "::error::Tests failed for $starter"
-      #             exit 1
-      #           fi
-      #           echo "✅ Tests passed for $starter"
-      #         else
-      #           echo "❌ No test:coverage script found for $starter - tests are mandatory"
-      #           echo "::error::No test:coverage script found for $starter"
-      #           exit 1
-      #         fi
-      #         
-      #         cd ../..
-      #       fi
-      #     done
+      - name: Run tests with coverage for all starters
+        env:
+          # Provide mock values for tests (in case they need Sitecore config)
+          SITECORE_EDGE_CONTEXT_ID: "mock-context-id-for-ci-tests"
+          NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID: "mock-context-id-for-ci-tests"
+          SITECORE_EDGE_URL: "https://edge.sitecorecloud.io"
+          NEXT_PUBLIC_SITECORE_EDGE_URL: "https://edge.sitecorecloud.io"
+          NEXT_PUBLIC_DEFAULT_SITE_NAME: "basic"
+          NEXT_PUBLIC_DEFAULT_LANGUAGE: "en"
+          SITECORE_EDITING_SECRET: "mock-editing-secret-for-ci-tests"
+        run: |
+          set -e  # Exit immediately if any command fails
+          echo "Running tests with coverage for all starters..."
+
+          # Test all enabled starters
+          for starter in kit-nextjs-skate-park kit-nextjs-article-starter kit-nextjs-location-finder kit-nextjs-product-listing; do
+            if [ -d "examples/$starter" ]; then
+              echo "=================================="
+              echo "Testing $starter"
+              echo "=================================="
+              cd "examples/$starter"
+
+              # Check if test:coverage script exists
+              if grep -q '"test:coverage:unit"' package.json; then
+                echo "Running tests with coverage for $starter..."
+                if ! npm run test:coverage:unit; then
+                  echo "❌ Tests failed for $starter"
+                  echo "::error::Tests failed for $starter"
+                  exit 1
+                fi
+                echo "✅ Tests passed for $starter"
+              else
+                echo "❌ No test:coverage:unit script found for $starter - tests are mandatory"
+                echo "::error::No test:coverage:unit script found for $starter"
+                exit 1
+              fi
+
+              cd ../..
+            fi
+          done
 
       - name: Comment PR with results
         if: always()
@@ -431,7 +430,7 @@ jobs:
               - ✅ Linting and formatting
               - ✅ TypeScript type checking
               - ${isUpstream ? '✅ Full build verification (Sitecore + Next.js)' : '✅ TypeScript compilation check (tsc --noEmit)'}
-              - ⏭️ Test execution with coverage (temporarily disabled for credential verification)
+              - ✅ Unit tests with coverage (npm run test:coverage:unit)
               ${!isUpstream ? '\n              **Note:** Full Next.js build requires XM Cloud credentials and will run in upstream CI.' : ''}
 
               **Next Steps:**

--- a/examples/kit-nextjs-article-starter/package.json
+++ b/examples/kit-nextjs-article-starter/package.json
@@ -160,7 +160,7 @@
     "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }

--- a/examples/kit-nextjs-article-starter/package.json
+++ b/examples/kit-nextjs-article-starter/package.json
@@ -161,6 +161,7 @@
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
   }
 }

--- a/examples/kit-nextjs-location-finder/package.json
+++ b/examples/kit-nextjs-location-finder/package.json
@@ -150,6 +150,7 @@
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
   }
 }

--- a/examples/kit-nextjs-location-finder/package.json
+++ b/examples/kit-nextjs-location-finder/package.json
@@ -149,7 +149,7 @@
     "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }

--- a/examples/kit-nextjs-product-listing/package.json
+++ b/examples/kit-nextjs-product-listing/package.json
@@ -147,6 +147,7 @@
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo",
     "test:coverage": "jest --coverage",
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo",
     "fix": "npm-run-all --serial lint:fix prettier",
     "lint:fix": "eslint ./src/**/*.tsx ./src/**/*.ts --fix",
     "prettier": "prettier --write \"./src/**/*.{ts,tsx,js,jsx,json,css,md}\"",

--- a/examples/kit-nextjs-skate-park/package.json
+++ b/examples/kit-nextjs-skate-park/package.json
@@ -71,7 +71,7 @@
     "test:geo": "jest --testPathPatterns=geo --coverage=false",
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
-    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo --coverage=false",
     "test:coverage": "jest --coverage"
   }

--- a/examples/kit-nextjs-skate-park/package.json
+++ b/examples/kit-nextjs-skate-park/package.json
@@ -72,6 +72,7 @@
     "test:watch": "jest --watch",
     "test:unit:watch": "jest --watch --testPathIgnorePatterns=geo",
     "test:geo:watch": "jest --watch --testPathPatterns=geo",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:coverage:unit": "jest --coverage --testPathIgnorePatterns=geo"
   }
 }


### PR DESCRIPTION

ci: run unit test coverage on PRs and DMZ

- Enable "Run tests with coverage for all starters" in pr-validation.yml and DMZ-validation
- Update PR comment checklist for coverage
- Scope test:coverage to unit tests via --testPathIgnorePatterns=geo (starters)