### PR TITLE
Fix(Code-Scanning): Incomplete URL substring sanitization - Location Finder

### DIFF
--- a/examples/kit-nextjs-location-finder/src/components/video/Video.tsx
+++ b/examples/kit-nextjs-location-finder/src/components/video/Video.tsx
@@ -19,7 +19,7 @@ import { Default as Icon } from '@/components/icon/Icon';
 import { Default as ImageWrapper } from '../image/ImageWrapper.dev';
 import { m } from 'framer-motion';
 import { isMobile } from '@/utils/isMobile';
-import { extractVideoId } from '@/utils/video';
+import { extractVideoId, isYouTubeThumbnailImageUrl } from '@/utils/video';
 import { NoDataFallback } from '@/utils/NoDataFallback';
 import { cn, getYouTubeThumbnail } from '@/lib/utils';
 import { Page } from '@sitecore-content-sdk/nextjs';
@@ -128,7 +128,7 @@ export function VideoBase({
                     alt=""
                     fill
                     className="object-cover"
-                    unoptimized={fallbackImage?.includes('youtube.com') || fallbackImage?.includes('ytimg.com')}
+                    unoptimized={isYouTubeThumbnailImageUrl(fallbackImage)}
                   />
                 </div>
               )}

--- a/examples/kit-nextjs-location-finder/src/utils/video.ts
+++ b/examples/kit-nextjs-location-finder/src/utils/video.ts
@@ -5,3 +5,16 @@ export const extractVideoId = (url: string | undefined) => {
   );
   return match && match[1].length === 11 ? match[1] : '';
 };
+
+/** Hostnames allowed for Next/Image unoptimized (YouTube thumbnail CDN only; parse host, do not substring-match URLs). */
+const YOUTUBE_THUMBNAIL_IMAGE_HOSTS = new Set(['img.youtube.com', 'i.ytimg.com']);
+
+export function isYouTubeThumbnailImageUrl(src: string | undefined): boolean {
+  if (!src || src.startsWith('/')) return false;
+  try {
+    const host = new URL(src).hostname.toLowerCase();
+    return YOUTUBE_THUMBNAIL_IMAGE_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
fix(video): parse thumbnail URLs for Next/Image unoptimized
- Add isYouTubeThumbnailImageUrl (img.youtube.com, i.ytimg.com) in
  kit-nextjs-location-finder; replace substring checks on fallbackImage.

solves code scanning alert: https://github.com/Sitecore/xmcloud-starter-js/security/code-scanning/7
https://github.com/Sitecore/xmcloud-starter-js/security/code-scanning/8