### PR TITLE
Add optional public site URL env vars to starter docs and .env examples

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -30,7 +30,7 @@ Each Next.js starter under `examples/*` uses this layout under `src/`. All of th
 
 - **Defined:** In `.env.remote.example` (or `.env.example`) at the root of each starter. Developers copy to `.env.local` for local development.
 - **Loaded:** Next.js loads `.env.local` automatically; **do not edit** `.env.local` or any `.env.*.local` in agent workflows.
-- **Consumed:** `sitecore.config.ts` and app code read `process.env.*` (e.g. `SITECORE_EDGE_CONTEXT_ID`, `NEXT_PUBLIC_DEFAULT_SITE_NAME`, `SITECORE_EDITING_SECRET`, `NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID`).
+- **Consumed:** `sitecore.config.ts` and app code read `process.env.*` (e.g. `SITECORE_EDGE_CONTEXT_ID`, `NEXT_PUBLIC_DEFAULT_SITE_NAME`, `SITECORE_EDITING_SECRET`, `NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID`, optional `NEXT_PUBLIC_SITE_URL` / `NEXT_PUBLIC_BASE_URL` for absolute URLs when no request host is available).
 
 **Where Content SDK (or JSS) is initialized**
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Use the **path for your chosen starter** (e.g. `examples/kit-nextjs-article-star
    Log into the [Sitecore XM Cloud Deploy Portal](https://portal.sitecorecloud.io), open your Environment → **Developer Settings**. Ensure **Preview** is enabled, then copy the sample `.env` contents from **Local Development**.
 
 2. **Create `.env.local`**  
-   In your starter folder (e.g. `examples/kit-nextjs-article-starter`), copy `.env.remote.example` to `.env.local` and paste the contents. Set at least: `SITECORE_EDGE_CONTEXT_ID`, `NEXT_PUBLIC_DEFAULT_SITE_NAME`, `NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID`, `SITECORE_EDITING_SECRET`. See [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html).
+   In your starter folder (e.g. `examples/kit-nextjs-article-starter`), copy `.env.remote.example` to `.env.local` and paste the contents. Set at least: `SITECORE_EDGE_CONTEXT_ID`, `NEXT_PUBLIC_DEFAULT_SITE_NAME`, `NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID`, `SITECORE_EDITING_SECRET`. See [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html). Optionally set `NEXT_PUBLIC_SITE_URL` or `NEXT_PUBLIC_BASE_URL` to your public site origin when server-rendered code must build absolute URLs without relying on the request `Host` header (see comments in `.env.remote.example`).
 
 3. **Install and run**
    ```bash

--- a/examples/basic-nextjs-pages-router/.env.container.example
+++ b/examples/basic-nextjs-pages-router/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/basic-nextjs-pages-router/.env.remote.example
+++ b/examples/basic-nextjs-pages-router/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/basic-nextjs-pages-router/README.md
+++ b/examples/basic-nextjs-pages-router/README.md
@@ -8,6 +8,8 @@ This is the basic Next.js starter using the **Pages Router**, with minimal XM Cl
 
 Follow the [root README — How to Run a Next.js Starter Locally](../../README.md#how-to-run-a-nextjs-starter-locally), using this path: **`examples/basic-nextjs-pages-router`**.
 
+Optional: for stable absolute URLs in server-rendered code when the request has no `Host` header, set `NEXT_PUBLIC_SITE_URL` or `NEXT_PUBLIC_BASE_URL` (see [`.env.remote.example`](.env.remote.example)).
+
 From the repo root:
 
 ```bash

--- a/examples/basic-nextjs/.env.container.example
+++ b/examples/basic-nextjs/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/basic-nextjs/.env.remote.example
+++ b/examples/basic-nextjs/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/basic-nextjs/README.md
+++ b/examples/basic-nextjs/README.md
@@ -8,6 +8,8 @@ This is the basic Next.js (App Router) starter with minimal XM Cloud integration
 
 Follow the [root README — How to Run a Next.js Starter Locally](../../README.md#how-to-run-a-nextjs-starter-locally), using this path: **`examples/basic-nextjs`**.
 
+Optional: for stable absolute URLs in server-rendered code when the request has no `Host` header, set `NEXT_PUBLIC_SITE_URL` or `NEXT_PUBLIC_BASE_URL` (see [`.env.remote.example`](.env.remote.example)).
+
 From the repo root:
 
 ```bash

--- a/examples/kit-nextjs-article-starter/.env.container.example
+++ b/examples/kit-nextjs-article-starter/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/kit-nextjs-article-starter/.env.remote.example
+++ b/examples/kit-nextjs-article-starter/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/kit-nextjs-article-starter/README.md
+++ b/examples/kit-nextjs-article-starter/README.md
@@ -32,7 +32,7 @@ Solterra & Co. is a polished, editorial-style template great for lifestyle brand
     ```cd examples\kit-nextjs-article-starter\```
 3. Copy the environment file ```.env.remote.example```
 4. Rename the copied file to ```.env.local```
-5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html))
+5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html)) Optionally set ```NEXT_PUBLIC_SITE_URL``` or ```NEXT_PUBLIC_BASE_URL``` to your public site origin when server-rendered code must build absolute URLs without the request ```Host``` header (see ```.env.remote.example```).
 
 6. Install dependencies:
    from ```kit-nextjs-article-starter``` run ```npm install```

--- a/examples/kit-nextjs-location-finder/.env.container.example
+++ b/examples/kit-nextjs-location-finder/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/kit-nextjs-location-finder/.env.remote.example
+++ b/examples/kit-nextjs-location-finder/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/kit-nextjs-location-finder/README.md
+++ b/examples/kit-nextjs-location-finder/README.md
@@ -32,7 +32,7 @@ Alaris is a bold, minimalist template perfect for showcasing premium products, w
     ```cd examples\kit-nextjs-location-finder\```
 3. Copy the environment file ```.env.remote.example```
 4. Rename the copied file to ```.env.local```
-5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html))
+5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html)) Optionally set ```NEXT_PUBLIC_SITE_URL``` or ```NEXT_PUBLIC_BASE_URL``` to your public site origin when server-rendered code must build absolute URLs without the request ```Host``` header (see ```.env.remote.example```).
 
 6. Install dependencies:
    from ```kit-nextjs-location-finder``` run ```npm install```

--- a/examples/kit-nextjs-product-listing/.env.container.example
+++ b/examples/kit-nextjs-product-listing/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/kit-nextjs-product-listing/.env.remote.example
+++ b/examples/kit-nextjs-product-listing/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/kit-nextjs-product-listing/README.md
+++ b/examples/kit-nextjs-product-listing/README.md
@@ -32,7 +32,7 @@ SYNC is a clean, bold, product-focused site template with a homepage, subpage, n
     ```cd examples\kit-nextjs-product-listing\```
 3. Copy the environment file ```.env.remote.example```
 4. Rename the copied file to ```.env.local```
-5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html))
+5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html)) Optionally set ```NEXT_PUBLIC_SITE_URL``` or ```NEXT_PUBLIC_BASE_URL``` to your public site origin when server-rendered code must build absolute URLs without the request ```Host``` header (see ```.env.remote.example```).
 
 6. Install dependencies:
    from ```kit-nextjs-product-listing``` run ```npm install```

--- a/examples/kit-nextjs-skate-park/.env.container.example
+++ b/examples/kit-nextjs-skate-park/.env.container.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_SITECORE_API_KEY=
 # Your Sitecore API hostname is needed to build the app.
 NEXT_PUBLIC_SITECORE_API_HOST=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # Sitecore Content SDK npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'content-sdk:*' to see all logs:

--- a/examples/kit-nextjs-skate-park/.env.remote.example
+++ b/examples/kit-nextjs-skate-park/.env.remote.example
@@ -19,6 +19,12 @@ SITECORE_EDGE_CONTEXT_ID=
 # Will be used as a fallback if separate SITECORE_EDGE_CONTEXT_ID value is not provided
 NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID=
 
+# Public origin of this site (e.g. https://www.example.com). Optional. Used when server code
+# builds absolute URLs (metadata, JSON-LD, sitemaps) without a request Host header.
+# NEXT_PUBLIC_SITE_URL is preferred; NEXT_PUBLIC_BASE_URL is used if the first is unset.
+NEXT_PUBLIC_SITE_URL=
+NEXT_PUBLIC_BASE_URL=
+
 # An optional Sitecore Personalize scope identifier.
 # This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
 # This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.

--- a/examples/kit-nextjs-skate-park/README.md
+++ b/examples/kit-nextjs-skate-park/README.md
@@ -32,7 +32,7 @@ Skate Park is a simple website with sample Component implementation showcasing d
     ```cd examples\kit-nextjs-skate-park\```
 3. Copy the environment file ```.env.remote.example```
 4. Rename the copied file to ```.env.local```
-5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html))
+5. Edit ```.env.local``` and provide a value for ```SITECORE_EDGE_CONTEXT_ID```, ```NEXT_PUBLIC_DEFAULT_SITE_NAME```, ```NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID```, ```SITECORE_EDITING_SECRET```. (More info: [Environment variables in XM Cloud](https://doc.sitecore.com/xmc/en/developers/xm-cloud/get-the-environment-variables-for-a-site.html)) Optionally set ```NEXT_PUBLIC_SITE_URL``` or ```NEXT_PUBLIC_BASE_URL``` to your public site origin when server-rendered code must build absolute URLs without the request ```Host``` header (see ```.env.remote.example```).
 
 6. Install dependencies:
    from ```kit-nextjs-skate-park``` run ```npm install```


### PR DESCRIPTION
<!--- ⚠️ IMPORTANT: This PR should target the `dmz` branch -->
<!--- Please ensure the base branch is set to `dmz` before creating this PR -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Agents.md: Documents where environment variables are handled for Next.js starters (defined in .env.remote.example / .env.example, loaded via .env.local, consumed in sitecore.config.ts and app code), including optional NEXT_PUBLIC_SITE_URL / NEXT_PUBLIC_BASE_URL for absolute URLs when there is no request host.
- Root README.md: Clarifies how to obtain env values and create .env.local, including optional NEXT_PUBLIC_SITE_URL / NEXT_PUBLIC_BASE_URL when server-rendered code must build absolute URLs without relying on the request Host header (with a pointer to comments in .env.remote.example).
- Per-starter README.md files (basic-nextjs, basic-nextjs-pages-router, kit-nextjs-article-starter, kit-nextjs-location-finder, kit-nextjs-product-listing, kit-nextjs-skate-park): Align “build and run locally” steps with the same optional URL variables and Sitecore env docs link.
- .env.remote.example and .env.container.example: Add (and document) NEXT_PUBLIC_SITE_URL and NEXT_PUBLIC_BASE_URL so examples match runtime needs for metadata, JSON-LD, sitemaps, and similar cases.

No application runtime logic is changed; this is documentation and example env alignment for consistent onboarding.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Terms
<!-- Place an `x` in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
