### PR TITLE
Add error handling tests for global and not-found pages, including fa…

### DIFF
--- a/examples/kit-nextjs-article-starter/src/__tests__/app/global-error.test.tsx
+++ b/examples/kit-nextjs-article-starter/src/__tests__/app/global-error.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import GlobalError from '@/app/global-error';
+import client from '@/lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_500_MESSAGE,
+  FALLBACK_500_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_SERVER_ERROR_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+jest.mock('@/lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+}));
+
+jest.mock('@/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('@/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('global-error page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_SERVER_ERROR_PAGE);
+
+      render(<GlobalError />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+          'Sitecore 500 Error Page'
+        );
+      });
+
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.InternalServerError, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch throws', async () => {
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/examples/kit-nextjs-article-starter/src/__tests__/app/not-found.test.tsx
+++ b/examples/kit-nextjs-article-starter/src/__tests__/app/not-found.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import NotFound from '@/app/[site]/[locale]/[[...path]]/not-found';
+import client from '@/lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_404_MESSAGE,
+  FALLBACK_404_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_NOT_FOUND_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+const mockGetCachedPageParams = jest.fn();
+
+jest.mock('@/lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+  getCachedPageParams: (...args: unknown[]) => mockGetCachedPageParams(...args),
+}));
+
+jest.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="next-intl-provider">{children}</div>
+  ),
+}));
+
+jest.mock('@/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('@/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('not-found page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCachedPageParams.mockReturnValue({ site: MOCK_SITE, locale: MOCK_LOCALE });
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_NOT_FOUND_PAGE);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByTestId('next-intl-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+        'Sitecore 404 Error Page'
+      );
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.NotFound, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/examples/kit-nextjs-article-starter/src/__tests__/test-utils/error-page-test-utils.ts
+++ b/examples/kit-nextjs-article-starter/src/__tests__/test-utils/error-page-test-utils.ts
@@ -1,0 +1,57 @@
+import type { Page, PageMode } from '@sitecore-content-sdk/nextjs';
+
+export const FALLBACK_404_TITLE = 'Page not found';
+export const FALLBACK_404_MESSAGE = 'This page does not exist.';
+export const FALLBACK_500_TITLE = '500 Internal Server Error';
+export const FALLBACK_500_MESSAGE =
+  'There is a problem with the resource you are looking for, and it cannot be displayed.';
+export const FALLBACK_HOME_LINK = 'Go to the Home page';
+
+export const MOCK_SITE = 'test-site';
+export const MOCK_LOCALE = 'en';
+
+export function createMockErrorPage(routeName: string, displayTitle?: string): Page {
+  return {
+    mode: {
+      isEditing: false,
+      isPreview: false,
+      isNormal: true,
+      name: 'normal' as PageMode['name'],
+      designLibrary: { isVariantGeneration: false },
+      isDesignLibrary: false,
+    },
+    layout: {
+      sitecore: {
+        context: {
+          language: MOCK_LOCALE,
+          site: { name: MOCK_SITE },
+        },
+        route: {
+          name: routeName,
+          displayName: displayTitle ?? routeName,
+          fields: {
+            Title: { value: displayTitle ?? routeName },
+          },
+          placeholders: {},
+        },
+      },
+    },
+    locale: MOCK_LOCALE,
+  } as Page;
+}
+
+export const MOCK_NOT_FOUND_PAGE = createMockErrorPage(
+  '404-error-page',
+  'Sitecore 404 Error Page'
+);
+
+export const MOCK_SERVER_ERROR_PAGE = createMockErrorPage(
+  '500-error-page',
+  'Sitecore 500 Error Page'
+);
+
+/** Matches `@sitecore-content-sdk/nextjs` ErrorPage enum values */
+export const ErrorPageType = {
+  NotFound: '404',
+  InternalServerError: '500',
+} as const;

--- a/examples/kit-nextjs-location-finder/jest.config.js
+++ b/examples/kit-nextjs-location-finder/jest.config.js
@@ -15,6 +15,7 @@ const customJestConfig = {
     '^sitecore\\.config$': '<rootDir>/sitecore.config.ts',
     // Handle module aliases (should match paths in tsconfig.json)
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^src/(.*)$': '<rootDir>/src/$1',
     '^components/(.*)$': '<rootDir>/src/components/$1',
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
     '^temp/(.*)$': '<rootDir>/src/temp/$1',

--- a/examples/kit-nextjs-location-finder/src/__tests__/app/not-found.test.tsx
+++ b/examples/kit-nextjs-location-finder/src/__tests__/app/not-found.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import NotFound from '@/app/[site]/[locale]/[[...path]]/not-found';
+import client from 'lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_404_MESSAGE,
+  FALLBACK_404_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_NOT_FOUND_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+const mockGetCachedPageParams = jest.fn();
+
+jest.mock('lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+  getCachedPageParams: (...args: unknown[]) => mockGetCachedPageParams(...args),
+}));
+
+jest.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="next-intl-provider">{children}</div>
+  ),
+}));
+
+jest.mock('src/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('src/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('not-found page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCachedPageParams.mockReturnValue({ site: MOCK_SITE, locale: MOCK_LOCALE });
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_NOT_FOUND_PAGE);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByTestId('next-intl-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+        'Sitecore 404 Error Page'
+      );
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.NotFound, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/examples/kit-nextjs-location-finder/src/__tests__/test-utils/error-page-test-utils.ts
+++ b/examples/kit-nextjs-location-finder/src/__tests__/test-utils/error-page-test-utils.ts
@@ -1,0 +1,57 @@
+import type { Page, PageMode } from '@sitecore-content-sdk/nextjs';
+
+export const FALLBACK_404_TITLE = 'Page not found';
+export const FALLBACK_404_MESSAGE = 'This page does not exist.';
+export const FALLBACK_500_TITLE = '500 Internal Server Error';
+export const FALLBACK_500_MESSAGE =
+  'There is a problem with the resource you are looking for, and it cannot be displayed.';
+export const FALLBACK_HOME_LINK = 'Go to the Home page';
+
+export const MOCK_SITE = 'test-site';
+export const MOCK_LOCALE = 'en';
+
+export function createMockErrorPage(routeName: string, displayTitle?: string): Page {
+  return {
+    mode: {
+      isEditing: false,
+      isPreview: false,
+      isNormal: true,
+      name: 'normal' as PageMode['name'],
+      designLibrary: { isVariantGeneration: false },
+      isDesignLibrary: false,
+    },
+    layout: {
+      sitecore: {
+        context: {
+          language: MOCK_LOCALE,
+          site: { name: MOCK_SITE },
+        },
+        route: {
+          name: routeName,
+          displayName: displayTitle ?? routeName,
+          fields: {
+            Title: { value: displayTitle ?? routeName },
+          },
+          placeholders: {},
+        },
+      },
+    },
+    locale: MOCK_LOCALE,
+  } as Page;
+}
+
+export const MOCK_NOT_FOUND_PAGE = createMockErrorPage(
+  '404-error-page',
+  'Sitecore 404 Error Page'
+);
+
+export const MOCK_SERVER_ERROR_PAGE = createMockErrorPage(
+  '500-error-page',
+  'Sitecore 500 Error Page'
+);
+
+/** Matches `@sitecore-content-sdk/nextjs` ErrorPage enum values */
+export const ErrorPageType = {
+  NotFound: '404',
+  InternalServerError: '500',
+} as const;

--- a/examples/kit-nextjs-product-listing/jest.config.js
+++ b/examples/kit-nextjs-product-listing/jest.config.js
@@ -10,6 +10,7 @@ const customJestConfig = {
   testTimeout: 15000,
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^src/(.*)$': '<rootDir>/src/$1',
     '^components/(.*)$': '<rootDir>/src/components/$1',
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
     '^shadcn/(.*)$': '<rootDir>/shadcn/$1',

--- a/examples/kit-nextjs-product-listing/src/__tests__/app/global-error.test.tsx
+++ b/examples/kit-nextjs-product-listing/src/__tests__/app/global-error.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import GlobalError from '@/app/global-error';
+import client from 'lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_500_MESSAGE,
+  FALLBACK_500_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_SERVER_ERROR_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+jest.mock('lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+}));
+
+jest.mock('src/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('src/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('global-error page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_SERVER_ERROR_PAGE);
+
+      render(<GlobalError />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+          'Sitecore 500 Error Page'
+        );
+      });
+
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.InternalServerError, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch throws', async () => {
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/examples/kit-nextjs-product-listing/src/__tests__/test-utils/error-page-test-utils.ts
+++ b/examples/kit-nextjs-product-listing/src/__tests__/test-utils/error-page-test-utils.ts
@@ -1,0 +1,57 @@
+import type { Page, PageMode } from '@sitecore-content-sdk/nextjs';
+
+export const FALLBACK_404_TITLE = 'Page not found';
+export const FALLBACK_404_MESSAGE = 'This page does not exist.';
+export const FALLBACK_500_TITLE = '500 Internal Server Error';
+export const FALLBACK_500_MESSAGE =
+  'There is a problem with the resource you are looking for, and it cannot be displayed.';
+export const FALLBACK_HOME_LINK = 'Go to the Home page';
+
+export const MOCK_SITE = 'test-site';
+export const MOCK_LOCALE = 'en';
+
+export function createMockErrorPage(routeName: string, displayTitle?: string): Page {
+  return {
+    mode: {
+      isEditing: false,
+      isPreview: false,
+      isNormal: true,
+      name: 'normal' as PageMode['name'],
+      designLibrary: { isVariantGeneration: false },
+      isDesignLibrary: false,
+    },
+    layout: {
+      sitecore: {
+        context: {
+          language: MOCK_LOCALE,
+          site: { name: MOCK_SITE },
+        },
+        route: {
+          name: routeName,
+          displayName: displayTitle ?? routeName,
+          fields: {
+            Title: { value: displayTitle ?? routeName },
+          },
+          placeholders: {},
+        },
+      },
+    },
+    locale: MOCK_LOCALE,
+  } as Page;
+}
+
+export const MOCK_NOT_FOUND_PAGE = createMockErrorPage(
+  '404-error-page',
+  'Sitecore 404 Error Page'
+);
+
+export const MOCK_SERVER_ERROR_PAGE = createMockErrorPage(
+  '500-error-page',
+  'Sitecore 500 Error Page'
+);
+
+/** Matches `@sitecore-content-sdk/nextjs` ErrorPage enum values */
+export const ErrorPageType = {
+  NotFound: '404',
+  InternalServerError: '500',
+} as const;

--- a/examples/kit-nextjs-skate-park/jest.config.js
+++ b/examples/kit-nextjs-skate-park/jest.config.js
@@ -117,6 +117,7 @@ const config = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^src/(.*)$': '<rootDir>/src/$1',
     '^components/(.*)$': '<rootDir>/src/components/$1',
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
     '^ui/(.*)$': '<rootDir>/src/components/ui/$1',

--- a/examples/kit-nextjs-skate-park/src/__tests__/app/global-error.test.tsx
+++ b/examples/kit-nextjs-skate-park/src/__tests__/app/global-error.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import GlobalError from '@/app/global-error';
+import client from 'lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_500_MESSAGE,
+  FALLBACK_500_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_SERVER_ERROR_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+jest.mock('lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+}));
+
+jest.mock('src/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('src/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('global-error page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_SERVER_ERROR_PAGE);
+
+      render(<GlobalError />);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+          'Sitecore 500 Error Page'
+        );
+      });
+
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.InternalServerError, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch throws', async () => {
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      render(<GlobalError />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_500_TITLE);
+      });
+
+      expect(screen.getByText(FALLBACK_500_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/examples/kit-nextjs-skate-park/src/__tests__/app/not-found.test.tsx
+++ b/examples/kit-nextjs-skate-park/src/__tests__/app/not-found.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { Page } from '@sitecore-content-sdk/nextjs';
+import NotFound from '@/app/[site]/[locale]/[[...path]]/not-found';
+import client from 'lib/sitecore-client';
+import {
+  ErrorPageType,
+  FALLBACK_404_MESSAGE,
+  FALLBACK_404_TITLE,
+  FALLBACK_HOME_LINK,
+  MOCK_LOCALE,
+  MOCK_NOT_FOUND_PAGE,
+  MOCK_SITE,
+} from '../test-utils/error-page-test-utils';
+
+const mockGetCachedPageParams = jest.fn();
+
+jest.mock('lib/sitecore-client', () => ({
+  __esModule: true,
+  default: {
+    getErrorPage: jest.fn(),
+  },
+}));
+
+jest.mock('sitecore.config', () => ({
+  __esModule: true,
+  default: {
+    defaultSite: 'test-site',
+    defaultLanguage: 'en',
+  },
+}));
+
+jest.mock('@sitecore-content-sdk/nextjs', () => ({
+  ErrorPage: {
+    NotFound: '404',
+    InternalServerError: '500',
+  },
+  getCachedPageParams: (...args: unknown[]) => mockGetCachedPageParams(...args),
+}));
+
+jest.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="next-intl-provider">{children}</div>
+  ),
+}));
+
+jest.mock('src/Layout', () => ({
+  __esModule: true,
+  default: ({ page }: { page: Page }) => (
+    <div data-testid="sitecore-error-layout">{page.layout.sitecore.route?.displayName}</div>
+  ),
+}));
+
+jest.mock('src/Providers', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sitecore-providers">{children}</div>
+  ),
+}));
+
+const mockGetErrorPage = jest.mocked(client.getErrorPage);
+
+describe('not-found page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCachedPageParams.mockReturnValue({ site: MOCK_SITE, locale: MOCK_LOCALE });
+  });
+
+  describe('when Sitecore error fetch succeeds', () => {
+    it('renders Sitecore error content', async () => {
+      mockGetErrorPage.mockResolvedValue(MOCK_NOT_FOUND_PAGE);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByTestId('next-intl-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-providers')).toBeInTheDocument();
+      expect(screen.getByTestId('sitecore-error-layout')).toHaveTextContent(
+        'Sitecore 404 Error Page'
+      );
+      expect(mockGetErrorPage).toHaveBeenCalledWith(ErrorPageType.NotFound, {
+        site: MOCK_SITE,
+        locale: MOCK_LOCALE,
+      });
+    });
+  });
+
+  describe('when Sitecore error fetch fails', () => {
+    it('renders fallback UI when fetch returns null', async () => {
+      mockGetErrorPage.mockResolvedValue(null);
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: FALLBACK_HOME_LINK })).toHaveAttribute('href', '/');
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+    });
+
+    it('renders fallback UI when fetch throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockGetErrorPage.mockRejectedValue(new Error('fetch failed'));
+
+      const component = await NotFound();
+      render(component);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(FALLBACK_404_TITLE);
+      expect(screen.getByText(FALLBACK_404_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByTestId('sitecore-error-layout')).not.toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/examples/kit-nextjs-skate-park/src/__tests__/test-utils/error-page-test-utils.ts
+++ b/examples/kit-nextjs-skate-park/src/__tests__/test-utils/error-page-test-utils.ts
@@ -1,0 +1,57 @@
+import type { Page, PageMode } from '@sitecore-content-sdk/nextjs';
+
+export const FALLBACK_404_TITLE = 'Page not found';
+export const FALLBACK_404_MESSAGE = 'This page does not exist.';
+export const FALLBACK_500_TITLE = '500 Internal Server Error';
+export const FALLBACK_500_MESSAGE =
+  'There is a problem with the resource you are looking for, and it cannot be displayed.';
+export const FALLBACK_HOME_LINK = 'Go to the Home page';
+
+export const MOCK_SITE = 'test-site';
+export const MOCK_LOCALE = 'en';
+
+export function createMockErrorPage(routeName: string, displayTitle?: string): Page {
+  return {
+    mode: {
+      isEditing: false,
+      isPreview: false,
+      isNormal: true,
+      name: 'normal' as PageMode['name'],
+      designLibrary: { isVariantGeneration: false },
+      isDesignLibrary: false,
+    },
+    layout: {
+      sitecore: {
+        context: {
+          language: MOCK_LOCALE,
+          site: { name: MOCK_SITE },
+        },
+        route: {
+          name: routeName,
+          displayName: displayTitle ?? routeName,
+          fields: {
+            Title: { value: displayTitle ?? routeName },
+          },
+          placeholders: {},
+        },
+      },
+    },
+    locale: MOCK_LOCALE,
+  } as Page;
+}
+
+export const MOCK_NOT_FOUND_PAGE = createMockErrorPage(
+  '404-error-page',
+  'Sitecore 404 Error Page'
+);
+
+export const MOCK_SERVER_ERROR_PAGE = createMockErrorPage(
+  '500-error-page',
+  'Sitecore 500 Error Page'
+);
+
+/** Matches `@sitecore-content-sdk/nextjs` ErrorPage enum values */
+export const ErrorPageType = {
+  NotFound: '404',
+  InternalServerError: '500',
+} as const;


### PR DESCRIPTION
…llback UI scenarios

<!--- ⚠️ IMPORTANT: This PR should target the `dmz` branch -->
<!--- Please ensure the base branch is set to `dmz` before creating this PR -->

> **New example sites:** This repository does **not** accept pull requests that add **new example sites**. If your change introduces a new top-level app under `examples/` (or equivalent), it will be out of scope. To publish your own app, use the repo as a [template](../README.md#github-template) or a fork. Details: [Contributing: what we do not accept](../CONTRIBUTING.md#what-we-do-not-accept).

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
*Please describe the context and motivation for this change. Why is this PR necessary? What problem does it solve or what feature does it add?*
*Include information on major design decisions, approaches taken, and any technical details important for reviewers to know.*

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

*Explain how to test this PR. Include specific areas to test, relevant test cases, and any setup required.*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Terms
<!-- Place an `x` in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
